### PR TITLE
reduce use of private dpd types in client-side code

### DIFF
--- a/dpd-client/src/lib.rs
+++ b/dpd-client/src/lib.rs
@@ -45,12 +45,12 @@ progenitor::generate_api!(
         slog::trace!(state.log, "client response"; "result" => ?result);
     }),
     derives = [ PartialEq ],
+    patch = {
+        PortId = {derives = [PartialOrd, Ord, PartialEq, Eq, Hash, Clone] },
+    },
     crates = {
         "oxnet" = "0.1.0",
     },
-    replace = {
-        PortId = common::ports::PortId,
-    }
 );
 
 impl Client {

--- a/dpd-client/tests/chaos_tests/port_settings.rs
+++ b/dpd-client/tests/chaos_tests/port_settings.rs
@@ -11,9 +11,8 @@ use super::harness::{
 use super::util::{link_list_ipv4, link_list_ipv6};
 use asic::chaos::{table, AsicConfig, Chaos, TableChaos};
 use asic::table_chaos;
-use common::ports::PortId;
 use dpd_client::types::{
-    LinkCreate, LinkId, LinkSettings, PortFec, PortSettings, PortSpeed,
+    LinkCreate, LinkId, LinkSettings, PortFec, PortId, PortSettings, PortSpeed,
 };
 use dpd_client::{Client, ROLLBACK_FAILURE_ERROR_CODE};
 use http::status::StatusCode;

--- a/dpd-client/tests/integration_tests/common.rs
+++ b/dpd-client/tests/integration_tests/common.rs
@@ -19,7 +19,6 @@ use oxnet::Ipv6Net;
 use slog::Drain;
 
 use ::common::network::MacAddr;
-use ::common::ports::PortId;
 use dpd_client::types;
 use dpd_client::Client;
 use dpd_client::ClientState;
@@ -31,6 +30,7 @@ use packet::ipv6;
 use packet::sidecar;
 use packet::Endpoint;
 use packet::Packet;
+use types::PortId;
 
 const SHOW_VERBOSE: u8 = 0x01;
 const SHOW_HEX: u8 = 0x02;

--- a/dpd-client/tests/integration_tests/port_api.rs
+++ b/dpd-client/tests/integration_tests/port_api.rs
@@ -14,9 +14,9 @@ use reqwest::StatusCode;
 
 use ::common::ports::Ipv4Entry;
 use ::common::ports::Ipv6Entry;
-use ::common::ports::PortId;
 use dpd_client::types;
 use dpd_client::Error;
+use types::PortId;
 
 use crate::integration_tests::common::prelude::*;
 

--- a/swadm/src/link.rs
+++ b/swadm/src/link.rs
@@ -18,7 +18,6 @@ use tabwriter::TabWriter;
 use common::counters::RMonCounters;
 use common::network::MacAddr;
 use common::ports::PortFec;
-use common::ports::PortId;
 use common::ports::PortMedia;
 use common::ports::PortPrbsMode;
 use common::ports::PortSpeed;
@@ -294,7 +293,7 @@ pub enum Link {
     List {
         /// The port whose links should be listed.
         #[structopt(parse(try_from_str = parse_port_id))]
-        port_id: PortId,
+        port_id: types::PortId,
         /// Provide machine-parseable output.
         #[structopt(short, long, requires("fields"))]
         parseable: bool,
@@ -402,7 +401,7 @@ pub enum Link {
 pub struct LinkCreate {
     /// The ID of the switch port on which to create the link.
     #[structopt(parse(try_from_str = parse_port_id))]
-    port_id: PortId,
+    port_id: types::PortId,
 
     /// The first lane of the port to use for this link
     #[structopt(long, parse(try_from_str))]

--- a/swadm/src/switchport.rs
+++ b/swadm/src/switchport.rs
@@ -15,9 +15,9 @@ use colored::*;
 use structopt::*;
 use tabwriter::TabWriter;
 
-use common::ports::{PortId, QsfpPort};
 use dpd_client::types::{
-    self, CmisDatapath, CmisLaneStatus, Sff8636Datapath, SffComplianceCode,
+    self, CmisDatapath, CmisLaneStatus, PortId, Sff8636Datapath,
+    SffComplianceCode,
 };
 use dpd_client::Client;
 
@@ -178,7 +178,7 @@ pub enum SwitchPort {
     ManagementMode {
         /// The QSFP port to operate on.
         #[structopt(parse(try_from_str = parse_qsfp_port_id))]
-        port_id: QsfpPort,
+        port_id: types::PortId,
     },
     /// Set the management mode for a switch port's transceiver.
     ///
@@ -187,7 +187,7 @@ pub enum SwitchPort {
     SetManagementMode {
         /// The QSFP port to operate on.
         #[structopt(parse(try_from_str = parse_qsfp_port_id))]
-        port_id: QsfpPort,
+        port_id: types::PortId,
         /// The management mode to set the port to.
         #[structopt(
             possible_values = &["automatic", "auto", "manual"],
@@ -926,16 +926,11 @@ pub async fn switch_cmd(
         }
         SwitchPort::Transceiver(xcvr) => transceivers_cmd(client, xcvr).await?,
         SwitchPort::ManagementMode { port_id } => {
-            let mode = client
-                .management_mode_get(&PortId::Qsfp(port_id))
-                .await?
-                .into_inner();
+            let mode = client.management_mode_get(&port_id).await?.into_inner();
             println!("{mode:?}");
         }
         SwitchPort::SetManagementMode { port_id, mode } => {
-            client
-                .management_mode_set(&PortId::Qsfp(port_id), mode)
-                .await?;
+            client.management_mode_set(&port_id, mode).await?;
         }
         SwitchPort::Led(led) => led_cmd(client, led).await?,
         SwitchPort::BackplaneMap {

--- a/tfportd/src/ports.rs
+++ b/tfportd/src/ports.rs
@@ -53,7 +53,7 @@ pub struct LinkInfo {
     /// The name of the link.
     pub name: String,
     /// The switch port ID for this link.
-    pub port_id: common::ports::PortId,
+    pub port_id: types::PortId,
     /// The link ID for this link.
     pub link_id: types::LinkId,
     /// The low-level Tofino ID used to refer to this link.
@@ -83,7 +83,7 @@ impl From<&types::TfportData> for LinkInfo {
     fn from(t: &types::TfportData) -> Self {
         LinkInfo {
             name: t.to_string(),
-            port_id: t.port_id,
+            port_id: t.port_id.clone(),
             link_id: t.link_id,
             asic_id: t.asic_id,
             mac: t.mac.clone().into(),

--- a/tfportd/src/simport.rs
+++ b/tfportd/src/simport.rs
@@ -107,7 +107,7 @@ async fn simnet_process(g: &Global) -> anyhow::Result<()> {
 
         // breakouts not a thing yet, just assume the 0th link
         let link_id = types::LinkId(0);
-        let port_id = match common::ports::PortId::from_str(port_name) {
+        let port_id = match types::PortId::from_str(port_name) {
             Ok(name) => name,
             Err(e) => {
                 error!(g.log, "failed to parse port name {port_name}: {e}");

--- a/tfportd/src/techport.rs
+++ b/tfportd/src/techport.rs
@@ -5,6 +5,7 @@
 // Copyright 2025 Oxide Computer Company
 
 use std::net::{Ipv6Addr, SocketAddrV6};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -17,8 +18,6 @@ use tokio::time::sleep;
 use crate::netsupport;
 use crate::Global;
 use common::illumos;
-use common::ports::InternalPort;
-use common::ports::PortId;
 use dpd_client::types;
 
 const ICMP6_RA_TYPE: u8 = 134;
@@ -130,7 +129,9 @@ async fn address_ensure_dpd(g: &Arc<Global>, pfx0: Ipv6Addr, pfx1: Ipv6Addr) {
         let addr1 = Ipv6Addr::from(u128::from(pfx1) | 1);
 
         // Techports are the internal port from an ASIC perspective.
-        let port = PortId::Internal(InternalPort::try_from(0).unwrap());
+        let port = types::PortId::from(
+            dpd_client::types::Internal::from_str("int0").unwrap(),
+        );
         let link = &types::LinkId(0);
 
         // Use the tfportd tag for making dpd entries.


### PR DESCRIPTION
This also makes it possible for clients to interact without needing to use `common::ports::PortId` rather than `dpd-client::types::PortId`.
