### PR TITLE
Report bit-error rates from links with RS FEC enabled

### DIFF
--- a/aal/src/lib.rs
+++ b/aal/src/lib.rs
@@ -26,6 +26,17 @@ pub type AsicId = u16;
 /// A specialized Result type for ASIC operations
 pub type AsicResult<T> = Result<T, AsicError>;
 
+/// Bit-error rates for a port.
+#[derive(Clone, Debug)]
+pub struct Ber {
+    /// FEC symbol error counters, per-lane.
+    pub symbol_errors: Vec<u64>,
+    /// Estimated BER, per-lane.
+    pub ber: Vec<f32>,
+    /// Aggregate BER on the port.
+    pub total_ber: f32,
+}
+
 /// Trait-bound for use by ASIC implementations to provide a set of identifiers.
 pub trait SidecarIdentifiers {
     fn id(&self) -> uuid::Uuid;
@@ -39,7 +50,7 @@ pub trait SidecarIdentifiers {
 /// Error type conveying additional information about ASIC errors
 #[derive(Error, Debug)]
 pub enum AsicError {
-    /// Error reported by the ASIC IDE.  This will report both the location
+    /// Error reported by the ASIC SDE.  This will report both the location
     /// in the ASIC layer that detected the error, as well as the detailed
     /// error message from the SDE.
     #[error("SDE error at {ctx}: {err}")]
@@ -139,6 +150,11 @@ pub trait AsicOps {
 
     /// Update a port's autonegotiation setting
     fn port_autoneg_set(&self, port_hdl: PortHdl, val: bool) -> AsicResult<()>;
+
+    /// Get the bit-error rate for a port.
+    fn port_ber_get(&self, _: PortHdl) -> AsicResult<Ber> {
+        Err(AsicError::OperationUnsupported)
+    }
 
     /// Set a port's PRBS mode
     fn port_prbs_set(

--- a/asic/src/tofino_asic/imported_bf_functions
+++ b/asic/src/tofino_asic/imported_bf_functions
@@ -94,6 +94,7 @@ bf_pm_port_kr_mode_get
 bf_pm_port_autoneg_set
 bf_pm_port_autoneg_get
 bf_pm_port_prbs_mode_set
+bf_pm_port_ber_get
 
 bf_eth_cpu_port_get
 bf_port_oper_state_get
@@ -102,6 +103,7 @@ bf_port_mac_stats_hw_sync_get
 bf_port_pcs_counters_get
 bf_port_rs_fec_status_and_counters_get
 bf_port_encoding_mode_get
+bf_port_speed_get
 
 bf_pm_port_media_type_get
 bf_pm_port_front_panel_port_get_first

--- a/asic/src/tofino_asic/imported_bf_types
+++ b/asic/src/tofino_asic/imported_bf_types
@@ -2,5 +2,6 @@ bf_rmon_counter_t
 bf_rmon_counter_array_t
 bf_pm_fsm_st
 pm_intf_fsm_states_t
+bf_port_ber_t
 qsfp_fsm_state_t
 qsfp_fsm_ch_en_state_t

--- a/asic/src/tofino_asic/mod.rs
+++ b/asic/src/tofino_asic/mod.rs
@@ -124,6 +124,10 @@ impl AsicOps for Handle {
         ports::set_prbs(self, port_hdl, mode)
     }
 
+    fn port_ber_get(&self, port_hdl: PortHdl) -> AsicResult<aal::Ber> {
+        ports::get_ber(self, port_hdl)
+    }
+
     fn port_add(
         &self,
         connector: Connector,

--- a/asic/src/tofino_asic/qsfp.rs
+++ b/asic/src/tofino_asic/qsfp.rs
@@ -391,7 +391,7 @@ pub extern "C" fn bf_pltfm_detect_qsfp(module: c_uint) -> bool {
     let Some(tx) = &*TRANSCEIVER_REQUEST_TX.read().unwrap() else {
         debug!(
             log,
-            "transceiver softsate not initialized, failing SDE request"
+            "transceiver softstate not initialized, failing SDE request"
         );
         return false;
     };
@@ -506,7 +506,7 @@ pub unsafe extern "C" fn write_qsfp_module(
     let Some(tx) = &*TRANSCEIVER_REQUEST_TX.read().unwrap() else {
         debug!(
             log,
-            "transceiver softsate not initialized, failing SDE request"
+            "transceiver softstate not initialized, failing SDE request"
         );
         return -1;
     };
@@ -601,7 +601,7 @@ pub unsafe extern "C" fn read_qsfp_module(
     let Some(tx) = &*TRANSCEIVER_REQUEST_TX.read().unwrap() else {
         debug!(
             log,
-            "transceiver softsate not initialized, failing SDE request"
+            "transceiver softstate not initialized, failing SDE request"
         );
         return -1;
     };

--- a/asic/src/tofino_asic/serdes.rs
+++ b/asic/src/tofino_asic/serdes.rs
@@ -56,8 +56,8 @@ fn port_encoding_mode(dev_id: i32, port_id: u16) -> AsicResult<LaneEncoding> {
     LaneEncoding::try_from(enc_mode)
 }
 
-// Get the number of lanes configured for this port
-fn lane_count(hdl: &Handle, port: PortHdl) -> AsicResult<u32> {
+/// Get the number of lanes configured for this port
+pub(crate) fn lane_count(hdl: &Handle, port: PortHdl) -> AsicResult<u32> {
     match hdl
         .phys_ports
         .lock()

--- a/dpd/src/tofino_api_server.rs
+++ b/dpd/src/tofino_api_server.rs
@@ -414,6 +414,25 @@ async fn link_an_lt_get(
         .map_err(|e| HttpError::from(DpdError::from(e)))
 }
 
+/// Return the estimated bit-error rate (BER) for a link.
+#[endpoint {
+    method = GET,
+    path = "/ports/{port_id}/links/{link_id}/ber",
+}]
+async fn link_ber_get(
+    rqctx: RequestContext<Arc<Switch>>,
+    path: Path<LinkPath>,
+) -> Result<HttpResponseOk<crate::link::Ber>, HttpError> {
+    let switch: &Switch = rqctx.context();
+    let path = path.into_inner();
+    let port_id = path.port_id;
+    let link_id = path.link_id;
+    switch
+        .link_ber(port_id, link_id)
+        .map(HttpResponseOk)
+        .map_err(|e| e.into())
+}
+
 pub fn init(api: &mut dropshot::ApiDescription<Arc<Switch>>) {
     api.register(pcs_counters_list).unwrap();
     api.register(pcs_counters_get).unwrap();
@@ -429,4 +448,5 @@ pub fn init(api: &mut dropshot::ApiDescription<Arc<Switch>>) {
     api.register(link_eye_get).unwrap();
     api.register(link_enc_speed_get).unwrap();
     api.register(link_an_lt_get).unwrap();
+    api.register(link_ber_get).unwrap();
 }

--- a/openapi/dpd.json
+++ b/openapi/dpd.json
@@ -2317,6 +2317,50 @@
         }
       }
     },
+    "/ports/{port_id}/links/{link_id}/ber": {
+      "get": {
+        "summary": "Return the estimated bit-error rate (BER) for a link.",
+        "operationId": "link_ber_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "link_id",
+            "description": "The link in the switch port on which to operate.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LinkId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "port_id",
+            "description": "The switch port on which to operate.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PortId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ber"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/ports/{port_id}/links/{link_id}/enabled": {
       "get": {
         "summary": "Return whether the link is enabled.",
@@ -5091,6 +5135,39 @@
           "sidecar_connector",
           "sidecar_leg",
           "tofino_connector"
+        ]
+      },
+      "Ber": {
+        "description": "Reports the bit-error rate (BER) for a link.",
+        "type": "object",
+        "properties": {
+          "ber": {
+            "description": "Estimated BER per-lane.",
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "symbol_errors": {
+            "description": "Counters of symbol errors per-lane.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          "total_ber": {
+            "description": "Aggregate BER on the link.",
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "required": [
+          "ber",
+          "symbol_errors",
+          "total_ber"
         ]
       },
       "BuildInfo": {

--- a/swadm/src/link.rs
+++ b/swadm/src/link.rs
@@ -111,6 +111,12 @@ pub enum LinkCounters {
         /// The link to fetch counters for.
         link: LinkPath,
     },
+
+    /// Fetch the estimated bit-error rate (BER) for a link.
+    Ber {
+        /// The link to fetch the BER for.
+        link: LinkPath,
+    },
 }
 
 /// Manage faults on ethernet links
@@ -674,6 +680,34 @@ async fn link_up_counters(
     for c in counters {
         writeln!(tw, "{}\t{}\t{}", c.link_path, c.current, c.total)?;
     }
+    tw.flush().map_err(|e| e.into())
+}
+
+async fn link_ber(client: &Client, link: LinkPath) -> anyhow::Result<()> {
+    let ber = client
+        .link_ber_get(&link.port_id, &link.link_id)
+        .await
+        .map(|r| r.into_inner())
+        .context("failed to get link BER")?;
+    let mut tw = TabWriter::new(stdout());
+    let mut total_symbol_errors: u64 = 0;
+    writeln!(
+        tw,
+        "{}\t{}\t{}",
+        "Lane".underline(),
+        "BER".underline(),
+        "Symbol errors".underline(),
+    )?;
+    for lane in 0..ber.ber.len() {
+        writeln!(
+            tw,
+            "{}\t{:0.3e}\t{}",
+            lane, ber.ber[lane], ber.symbol_errors[lane],
+        )?;
+        total_symbol_errors =
+            total_symbol_errors.saturating_add(ber.symbol_errors[lane]);
+    }
+    writeln!(tw, "Total\t{:0.3e}\t{}", ber.total_ber, total_symbol_errors,)?;
     tw.flush().map_err(|e| e.into())
 }
 
@@ -1835,6 +1869,9 @@ pub async fn link_cmd(client: &Client, link: Link) -> anyhow::Result<()> {
                     .await
                     .context("failed to fetch fsm state counters")?;
             }
+            LinkCounters::Ber { link } => link_ber(client, link)
+                .await
+                .context("failed to fetch link BER")?,
         },
         Link::Serdes(serdes) => match serdes {
             Serdes::Get(get) => match get {


### PR DESCRIPTION
- Add ASIC-layer methods for reporting the BER from an ASIC port
- Export Tofino2 functions and types for reading BER out of the PHY
- Add `dpd` and `swadm` interfaces for extracting the BER and printing it