### PR TITLE
Add MSS Geneve option, support several Geneve options

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -101,7 +101,7 @@ pfexec chown "$UID" /out
 
 banner "P4 Codegen"
 # Add gcc-12 so the p4 compiler can find cpp
-# The tofino2 has 20 stages, but the current sidecar.p4 will fit into 18.  We
+# The tofino2 has 20 stages, but the current sidecar.p4 will fit into 19.  We
 # add the "--stages 19" here to detect if/when the program grows beyond that
 # limit.  It's not necessarily a problem if we grow, but given the limited space
 # on the ASIC, we want to grow deliberatately and thoughtfully.

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -102,10 +102,10 @@ pfexec chown "$UID" /out
 banner "P4 Codegen"
 # Add gcc-12 so the p4 compiler can find cpp
 # The tofino2 has 20 stages, but the current sidecar.p4 will fit into 18.  We
-# add the "--stages 18" here to detect if/when the program grows beyond that
+# add the "--stages 19" here to detect if/when the program grows beyond that
 # limit.  It's not necessarily a problem if we grow, but given the limited space
 # on the ASIC, we want to grow deliberatately and thoughtfully.
-PATH=/opt/gcc-12/bin:$PATH cargo xtask codegen --stages 18
+PATH=/opt/gcc-12/bin:$PATH cargo xtask codegen --stages 19
 
 # Preserve all the diagnostics spit out by the compiler
 mkdir -p /out/p4c-diags

--- a/dpd-client/tests/integration_tests/geneve.rs
+++ b/dpd-client/tests/integration_tests/geneve.rs
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/
+//
+// Copyright 2025 Oxide Computer Company
+
+use std::sync::Arc;
+
+use packet::eth;
+use packet::geneve;
+use packet::Endpoint;
+
+use crate::integration_tests::common;
+use crate::integration_tests::common::prelude::*;
+
+// Build a UDP packet with a Geneve payload.  Because it isn't addressed to a
+// switch IP address, the switch should forward it unmolested.
+#[tokio::test]
+#[ignore]
+async fn test_geneve() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let ingress_port = PhysPort(10);
+    let uplink_port = PhysPort(14);
+    let router_ip = "fd00:1122:3344:0101::1";
+    let uplink_route = "fd00:1122:3344:0101::/56";
+    let router_mac = "02:aa:bb:cc:dd:ee".parse()?;
+    common::set_route_ipv6(switch, uplink_route, uplink_port, router_ip)
+        .await?;
+    common::add_neighbor_ipv6(switch, router_ip, router_mac).await?;
+
+    let vpc_src_ip = "172.16.10.33";
+    let vpc_src_mac = "04:01:01:01:01:01";
+    let vpc_src_port = 3333;
+    let vpc_dst_ip = "10.10.10.2";
+    let vpc_dst_mac = "04:01:01:01:01:02";
+    let vpc_dst_port = 4444;
+    let payload = common::gen_udp_packet(
+        Endpoint::parse(vpc_src_mac, vpc_src_ip, vpc_src_port).unwrap(),
+        Endpoint::parse(vpc_dst_mac, vpc_dst_ip, vpc_dst_port).unwrap(),
+    )
+    .deparse()
+    .unwrap()
+    .to_vec();
+
+    let mut to_send = common::gen_geneve_packet(
+        Endpoint::parse("e0:d5:5e:67:89:ab", "fd00:1122:7788:0101::4", 3333)
+            .unwrap(),
+        Endpoint::parse(
+            "e0:d5:5e:67:89:ac",
+            "fd00:1122:3344:0101::5",
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV4,
+        345,
+        &[],
+        &payload,
+    );
+    eth::EthHdr::rewrite_dmac(&mut to_send, router_mac);
+    let to_recv = common::gen_packet_routed(switch, uplink_port, &to_send);
+    let send = TestPacket {
+        packet: Arc::new(to_send),
+        port: ingress_port,
+    };
+    let expected = TestPacket {
+        packet: Arc::new(to_recv),
+        port: uplink_port,
+    };
+
+    // These tests are a bit slower, for non-obvious reasons.
+    switch.packet_test(vec![send], vec![expected])
+}
+
+// Sidecar can carry several geneve options between underlay ports.
+// Note: we do not guarantee this is order-preserving!
+#[tokio::test]
+#[ignore]
+async fn test_geneve_multiopt() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let ingress_port = PhysPort(10);
+    let uplink_port = PhysPort(14);
+    let router_ip = "fd00:1122:3344:0101::1";
+    let uplink_route = "fd00:1122:3344:0101::/56";
+    let router_mac = "02:aa:bb:cc:dd:ee".parse()?;
+    common::set_route_ipv6(switch, uplink_route, uplink_port, router_ip)
+        .await?;
+    common::add_neighbor_ipv6(switch, router_ip, router_mac).await?;
+
+    let vpc_src_ip = "172.16.10.33";
+    let vpc_src_mac = "04:01:01:01:01:01";
+    let vpc_src_port = 3333;
+    let vpc_dst_ip = "10.10.10.2";
+    let vpc_dst_mac = "04:01:01:01:01:02";
+    let vpc_dst_port = 4444;
+    let payload = common::gen_udp_packet(
+        Endpoint::parse(vpc_src_mac, vpc_src_ip, vpc_src_port).unwrap(),
+        Endpoint::parse(vpc_dst_mac, vpc_dst_ip, vpc_dst_port).unwrap(),
+    )
+    .deparse()
+    .unwrap()
+    .to_vec();
+
+    let mut to_send = common::gen_geneve_packet(
+        Endpoint::parse("e0:d5:5e:67:89:ab", "fd00:1122:7788:0101::4", 3333)
+            .unwrap(),
+        Endpoint::parse(
+            "e0:d5:5e:67:89:ac",
+            "fd00:1122:3344:0101::5",
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV4,
+        345,
+        &[
+            // Does this combination make sense? Maybe not today, but
+            // we could have a type-zero-with-body (if we have it carry the
+            // VNI origin for e.g. VPC peering) combined with MSS.
+            // Ditto for its combination with multicast info.
+            common::OxideGeneveOption::External,
+            common::OxideGeneveOption::Mss(1448),
+        ],
+        &payload,
+    );
+    eth::EthHdr::rewrite_dmac(&mut to_send, router_mac);
+    let to_recv = common::gen_packet_routed(switch, uplink_port, &to_send);
+    let send = TestPacket {
+        packet: Arc::new(to_send),
+        port: ingress_port,
+    };
+    let to_recv = Arc::new(to_recv);
+    let expected = TestPacket {
+        packet: Arc::clone(&to_recv),
+        port: uplink_port,
+    };
+
+    switch.packet_test(vec![send], vec![expected])?;
+
+    // Now, verify that options are present (but canonically ordered)
+    // if we put them in in a different order.
+    let mut to_send = common::gen_geneve_packet(
+        Endpoint::parse("e0:d5:5e:67:89:ab", "fd00:1122:7788:0101::4", 3333)
+            .unwrap(),
+        Endpoint::parse(
+            "e0:d5:5e:67:89:ac",
+            "fd00:1122:3344:0101::5",
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV4,
+        345,
+        &[
+            // Swapped!
+            common::OxideGeneveOption::Mss(1448),
+            common::OxideGeneveOption::External,
+        ],
+        &payload,
+    );
+    eth::EthHdr::rewrite_dmac(&mut to_send, router_mac);
+    let send = TestPacket {
+        packet: Arc::new(to_send),
+        port: ingress_port,
+    };
+    let expected = TestPacket {
+        packet: to_recv,
+        port: uplink_port,
+    };
+
+    // Sidecar, at least for today, orders options by ID.
+    switch.packet_test(vec![send], vec![expected])
+}

--- a/dpd-client/tests/integration_tests/mcast.rs
+++ b/dpd-client/tests/integration_tests/mcast.rs
@@ -10,10 +10,8 @@ use std::{
     sync::Arc,
 };
 
-use crate::integration_tests::{
-    common::{self, get_switch, prelude::*},
-    nat::{gen_geneve_packet, gen_geneve_packet_with_mcast_tag},
-};
+use crate::integration_tests::common;
+use crate::integration_tests::common::prelude::*;
 use ::common::network::MacAddr;
 use anyhow::anyhow;
 use dpd_client::{types, Error};
@@ -324,7 +322,7 @@ fn prepare_expected_pkt(
                 .unwrap()
                 .to_string();
 
-            let mut forward_pkt = gen_geneve_packet(
+            let mut forward_pkt = common::gen_external_geneve_packet(
                 Endpoint::parse(
                     &switch_port_mac,
                     "::0",
@@ -339,7 +337,6 @@ fn prepare_expected_pkt(
                 .unwrap(),
                 eth::ETHER_ETHER,
                 *nat.vni,
-                true,
                 &ingress_payload,
             );
 
@@ -1975,7 +1972,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_external_members(
     // Create the Geneve packet with mcast_tag = 0
     // According to mcast_tag_check table, when geneve.isValid() is true and
     // mcast_tag is 0, it should invalidate the underlay group and set decap
-    let geneve_pkt = gen_geneve_packet_with_mcast_tag(
+    let geneve_pkt = common::gen_geneve_packet_with_mcast_tag(
         Endpoint::parse(
             GIMLET_MAC,
             &GIMLET_IP.to_string(),
@@ -1990,8 +1987,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_external_members(
         .unwrap(),
         eth::ETHER_IPV4,
         nat_target.vni.clone().into(),
-        true,    // tag_ingress = true to enable option setting
-        Some(0), // mcast_tag = 0
+        0, // mcast_tag = 0
         &payload,
     );
 
@@ -2117,13 +2113,12 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_members(
     // Create the Geneve packet with mcast_tag = 1
     // According to mcast_tag_check table, when geneve.isValid() is true and
     // mcast_tag is 1, it should invalidate the external group and not decap
-    let geneve_pkt = gen_geneve_packet_with_mcast_tag(
+    let geneve_pkt = common::gen_geneve_packet_with_mcast_tag(
         geneve_src,
         geneve_dst,
         eth::ETHER_IPV4,
         nat_target.vni.clone().into(),
-        true,    // tag_ingress = true to enable option setting
-        Some(1), // mcast_tag = 1
+        1, // mcast_tag = 1
         &payload,
     );
 
@@ -2248,7 +2243,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_and_external_membe
     // According to mcast_tag_check table, when geneve.isValid() is true and
     // mcast_tag is 2, it should not invalidate any group, decapping only the
     // external group(s)
-    let geneve_pkt = gen_geneve_packet_with_mcast_tag(
+    let geneve_pkt = common::gen_geneve_packet_with_mcast_tag(
         Endpoint::parse(
             GIMLET_MAC,
             &GIMLET_IP.to_string(),
@@ -2263,8 +2258,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_and_external_membe
         .unwrap(),
         eth::ETHER_IPV4,
         nat_target.vni.clone().into(),
-        true,    // tag_ingress = true to enable option setting
-        Some(2), // mcast_tag = 2
+        2, // mcast_tag = 2
         &payload,
     );
 

--- a/dpd-client/tests/integration_tests/mod.rs
+++ b/dpd-client/tests/integration_tests/mod.rs
@@ -6,6 +6,7 @@
 
 mod common;
 mod counters;
+mod geneve;
 mod icmp_ipv4;
 mod loopback;
 mod mcast;

--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -85,5 +85,8 @@ const bit<8> DROP_MULTICAST_INVALID_MAC         = 0x13;
 const bit<8> DROP_MULTICAST_CPU_COPY            = 0x14;
 const bit<8> DROP_MULTICAST_SOURCE_FILTERED     = 0x15;
 const bit<8> DROP_MULTICAST_PATH_FILTERED       = 0x16;
-const bit<32> DROP_REASON_MAX                   = 0x17;
+const bit<8> DROP_GENEVE_OPTION_TOO_LONG        = 0x17;
+const bit<8> DROP_GENEVE_OPTION_MALFORMED       = 0x18;
+// MAX(DROP_xxx) + 1
+const bit<32> DROP_REASON_MAX                   = 0x19;
 

--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -85,7 +85,7 @@ const bit<8> DROP_MULTICAST_INVALID_MAC         = 0x13;
 const bit<8> DROP_MULTICAST_CPU_COPY            = 0x14;
 const bit<8> DROP_MULTICAST_SOURCE_FILTERED     = 0x15;
 const bit<8> DROP_MULTICAST_PATH_FILTERED       = 0x16;
-const bit<8> DROP_GENEVE_OPTION_TOO_LONG        = 0x17;
+const bit<8> DROP_GENEVE_OPTIONS_TOO_LONG       = 0x17;
 const bit<8> DROP_GENEVE_OPTION_MALFORMED       = 0x18;
 const bit<8> DROP_GENEVE_OPTION_UNKNOWN         = 0x19;
 // MAX(DROP_xxx) + 1

--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -89,5 +89,5 @@ const bit<8> DROP_GENEVE_OPTIONS_TOO_LONG       = 0x17;
 const bit<8> DROP_GENEVE_OPTION_MALFORMED       = 0x18;
 const bit<8> DROP_GENEVE_OPTION_UNKNOWN         = 0x19;
 // MAX(DROP_xxx) + 1
-const bit<32> DROP_REASON_MAX                   = 0x20;
+const bit<32> DROP_REASON_MAX                   = 0x1A;
 

--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -87,6 +87,7 @@ const bit<8> DROP_MULTICAST_SOURCE_FILTERED     = 0x15;
 const bit<8> DROP_MULTICAST_PATH_FILTERED       = 0x16;
 const bit<8> DROP_GENEVE_OPTION_TOO_LONG        = 0x17;
 const bit<8> DROP_GENEVE_OPTION_MALFORMED       = 0x18;
+const bit<8> DROP_GENEVE_OPTION_UNKNOWN         = 0x19;
 // MAX(DROP_xxx) + 1
-const bit<32> DROP_REASON_MAX                   = 0x19;
+const bit<32> DROP_REASON_MAX                   = 0x20;
 

--- a/dpd/p4/headers.p4
+++ b/dpd/p4/headers.p4
@@ -158,7 +158,8 @@ header geneve_h {
 
 const bit<16> GENEVE_OPT_CLASS_OXIDE	= 0x0129;
 const bit<7> GENEVE_OPT_OXIDE_EXTERNAL	= 0x00;
-const bit<7> GENEVE_OPT_OXIDE_MCAST	= 0x01; // Multicast tag
+const bit<7> GENEVE_OPT_OXIDE_MCAST	= 0x01;
+const bit<7> GENEVE_OPT_OXIDE_MSS	= 0x02;
 
 header geneve_opt_h {
 	bit<16> class;
@@ -183,15 +184,28 @@ header geneve_opt_mcast_h {
 	bit<30> reserved;
 }
 
+
+header geneve_opt_mss_h {
+	bit<32> mss;
+}
+
 // Since we're a TEP, we need to push and read Geneve options.
 // `varbit` only allows us to carry.
 // XXX: For parsing past one option, add `extern ParserCounter`
-//      to oxidecomputer/p4/lang/p4rs/src/externs.rs, consider
-//      storing via `header_union`s.
+//      to oxidecomputer/p4/lang/p4rs/src/externs.rs.
+// XXX: these are stored adjacently because:
+//      `error: Unsupported type header_union geneve_opt_body_h`
 struct geneve_opt_headers_t {
-	geneve_opt_h ox_external_tag;
-	// Multicast-specific options
+	geneve_opt_h opt_tag;
+
+	// External Packet tag (0x00)
+	// <<no body>>
+
+	// Multicast-specific options (0x01)
 	geneve_opt_mcast_h ox_mcast_tag;
+
+	// MSS option [OPTE-only] (0x02)
+	geneve_opt_mss_h ox_mss_tag;
 }
 
 struct sidecar_headers_t {

--- a/dpd/p4/headers.p4
+++ b/dpd/p4/headers.p4
@@ -191,21 +191,24 @@ header geneve_opt_mss_h {
 
 // Since we're a TEP, we need to push and read Geneve options.
 // `varbit` only allows us to carry.
-// XXX: For parsing past one option, add `extern ParserCounter`
-//      to oxidecomputer/p4/lang/p4rs/src/externs.rs.
-// XXX: these are stored adjacently because:
-//      `error: Unsupported type header_union geneve_opt_body_h`
+// These are stored adjacently (rather than a header stack), which
+// has the caveat that we won't preserve the order of any options which
+// we understand.
+//
+// The other issue in using a headerstack is that `header_union`s appear
+// to be unsupported.
 struct geneve_opt_headers_t {
-	geneve_opt_h opt_tag;
-
 	// External Packet tag (0x00)
+	geneve_opt_h oxg_ext_tag;
 	// <<no body>>
 
 	// Multicast-specific options (0x01)
-	geneve_opt_mcast_h ox_mcast_tag;
+	geneve_opt_h oxg_mcast_tag;
+	geneve_opt_mcast_h oxg_mcast;
 
 	// MSS option [OPTE-only] (0x02)
-	geneve_opt_mss_h ox_mss_tag;
+	geneve_opt_h oxg_mss_tag;
+	geneve_opt_mss_h oxg_mss;
 }
 
 struct sidecar_headers_t {

--- a/dpd/p4/metadata.p4
+++ b/dpd/p4/metadata.p4
@@ -48,6 +48,8 @@ struct sidecar_ingress_meta_t {
 	ipv4_addr_t orig_dst_ipv4;	// original ipv4 target
 
 	bridge_h bridge_hdr;		// bridge header
+
+	bit<16> nat_ingress_csum;
 }
 
 struct sidecar_egress_meta_t {

--- a/dpd/p4/parser.p4
+++ b/dpd/p4/parser.p4
@@ -394,15 +394,15 @@ parser IngressParser(
 	}
 
 	state parse_geneve_opt {
-		pkt.extract(hdr.geneve_opts.ox_external_tag);
-		transition select(hdr.geneve_opts.ox_external_tag.class) {
+		pkt.extract(hdr.geneve_opts.opt_tag);
+		transition select(hdr.geneve_opts.opt_tag.class) {
 			GENEVE_OPT_CLASS_OXIDE: parse_geneve_ox_opt;
 			default: reject;
 		}
 	}
 
 	state parse_geneve_ox_opt {
-		transition select(hdr.geneve_opts.ox_external_tag.type) {
+		transition select(hdr.geneve_opts.opt_tag.type) {
 			GENEVE_OPT_OXIDE_EXTERNAL: geneve_parsed;
 			GENEVE_OPT_OXIDE_MCAST: parse_geneve_mcast_tag;
 			default: reject;
@@ -587,22 +587,29 @@ parser EgressParser(
 	}
 
 	state parse_geneve_opt {
-		pkt.extract(hdr.geneve_opts.ox_external_tag);
-		transition select(hdr.geneve_opts.ox_external_tag.class) {
+		pkt.extract(hdr.geneve_opts.opt_tag);
+		transition select(hdr.geneve_opts.opt_tag.class) {
 			GENEVE_OPT_CLASS_OXIDE: parse_geneve_ox_opt;
 			default: reject;
 		}
 	}
 
 	state parse_geneve_ox_opt {
-		transition select(hdr.geneve_opts.ox_external_tag.type) {
+		transition select(hdr.geneve_opts.opt_tag.type) {
+			GENEVE_OPT_OXIDE_EXTERNAL: geneve_parsed;
 			GENEVE_OPT_OXIDE_MCAST: parse_geneve_mcast_tag;
+			GENEVE_OPT_OXIDE_MSS: parse_geneve_mss_tag;
 			default: reject;
 		}
 	}
 
 	state parse_geneve_mcast_tag {
 		pkt.extract(hdr.geneve_opts.ox_mcast_tag);
+		transition geneve_parsed;
+	}
+
+	state parse_geneve_mss_tag {
+		pkt.extract(hdr.geneve_opts.ox_mss_tag);
 		transition geneve_parsed;
 	}
 

--- a/dpd/p4/parser.p4
+++ b/dpd/p4/parser.p4
@@ -443,7 +443,7 @@ parser IngressParser(
 	}
 
 	state geneve_bad_size {
-		meta.drop_reason = DROP_GENEVE_OPTION_TOO_LONG;
+		meta.drop_reason = DROP_GENEVE_OPTIONS_TOO_LONG;
 		meta.is_valid = false;
 		transition accept;
 	}

--- a/dpd/p4/sidecar.p4
+++ b/dpd/p4/sidecar.p4
@@ -1981,6 +1981,16 @@ control Ingress(
 			//   be the easier one to fix in tofino-p4c. This
 			//   `todo!()` covers various other tricks, including
 			//   wrapping the const in a struct/header.
+			//
+			// This value is derived from the geneve option pushed in
+			// NatIngress:
+			//
+			//              class = GENEVE_OPT_CLASS_OXIDE
+			//                           vvvvvvvvvv
+			//                           0x01, 0x29
+			//                           0x00, 0x00
+			//                             ^^    ^^
+			// id = GENEVE_OPT_OXIDE_EXTERNAL    reserved, len = 0
 			meta.nat_ingress_csum = 16w0x0129;
 		}
 	}

--- a/dpd/src/counters.rs
+++ b/dpd/src/counters.rs
@@ -262,6 +262,9 @@ enum DropReason {
     MulticastCpuCopy,
     MulticastSrcFiltered,
     MulticastPathFiltered,
+    GeneveOptionsTooLong,
+    GeneveOptionMalformed,
+    GeneveOptionUnknown,
 }
 
 impl TryFrom<u8> for DropReason {
@@ -292,6 +295,9 @@ impl TryFrom<u8> for DropReason {
             20 => Ok(DropReason::MulticastCpuCopy),
             21 => Ok(DropReason::MulticastSrcFiltered),
             22 => Ok(DropReason::MulticastPathFiltered),
+            23 => Ok(DropReason::GeneveOptionsTooLong),
+            24 => Ok(DropReason::GeneveOptionMalformed),
+            25 => Ok(DropReason::GeneveOptionUnknown),
             x => Err(format!("Unrecognized drop reason: {x}")),
         }
     }
@@ -330,6 +336,13 @@ fn reason_label(ctr: u8) -> Result<Option<String>, String> {
         DropReason::MulticastPathFiltered => {
             "multicast_path_filtered".to_string()
         }
+        DropReason::GeneveOptionsTooLong => {
+            "geneve_options_too_long".to_string()
+        }
+        DropReason::GeneveOptionMalformed => {
+            "geneve_option_malformed".to_string()
+        }
+        DropReason::GeneveOptionUnknown => "geneve_option_unknown".to_string(),
     };
     Ok(Some(label))
 }


### PR DESCRIPTION
This PR retools our parsing of Geneve options to rely upon a `ParserCounter`. This allows us to keep track of how many 4B chunks within the header are remaining after successfully parsing each option, and to reject packets with overly long option lists.

Limitations:
* Output packets will have all their Geneve options reordered, since we do not make use of a header stack.
* We support at most one of each Geneve option, which is probably reasonable enough.
* We don't have a mechanism for transit of *unknown* Geneve options, so no forward-compatibility yet.

See also https://github.com/oxidecomputer/sidecar-lite/pull/79, https://github.com/oxidecomputer/opte/pull/805.