### PR TITLE
[cleanup] Remove unnecessary mcast tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "oxnet"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e1dc143c5a701f879552428910f357df8bd725575087cc713088fdfeafe812"
+checksum = "8200429754152e6379fbb1dd06eea90156c3b67591f6e31d08e787d010ef0168"
 dependencies = [
  "ipnetwork",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch= "ma
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branch = "main", default-features = false, features = ["kstat"] }
-oxnet = { version = "0.1.2", default-features = false, features = ["schemars", "serde"] }
+oxnet = { version = "0.1.3", default-features = false, features = ["schemars", "serde"] }
 propolis = { git = "https://github.com/oxidecomputer/propolis" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 smf = { git = "https://github.com/illumos/smf-rs" }

--- a/dpd/p4/sidecar.p4
+++ b/dpd/p4/sidecar.p4
@@ -2152,8 +2152,8 @@ control Egress(
 				underlay_mcast_ctr.count(eg_intr_md.egress_port);
 			}
 		} else {
-			# non-multicast packets should bypass the egress
-			# pipeline, so we would expect this to be 0.
+			// non-multicast packets should bypass the egress
+			// pipeline, so we would expect this to be 0.
 			unicast_ctr.count(eg_intr_md.egress_port);
 		}
 	}


### PR DESCRIPTION
The exclusion/prune and no_admin_ula mcast integration tests were unnecessary  and part of previously configurable code that was made obsolete during the last review cycle of the large mcast PR.

The exclusion/prune test was being flaky on CI, but didn't set up proper MAC linking anyway. It's not useful because we force 0 for the exclusion flag when we configure replication on the underlay groups.

Includes:
  * use oxnet's derive mac facility for tests, updating the dep
  * mcast integration test comment cleanup
  * move P4 # comment to //