### PR TITLE
[mcast] Lifecycle + API changes for Omicron impl

### DIFF
--- a/dpd-client/tests/integration_tests/mcast.rs
+++ b/dpd-client/tests/integration_tests/mcast.rs
@@ -182,7 +182,6 @@ async fn create_test_multicast_group(
                         _ => panic!("Expected IPv6 address"),
                     },
                     tag: tag.map(String::from),
-                    sources,
                     members,
                 };
                 switch
@@ -213,9 +212,16 @@ async fn create_test_multicast_group(
     }
 }
 
-/// Clean up a test group.
-async fn cleanup_test_group(switch: &Switch, group_ip: IpAddr) {
-    let _ = switch.client.multicast_group_delete(&group_ip).await;
+/// Clean up a test group, failing if it cannot be deleted properly.
+async fn cleanup_test_group(switch: &Switch, group_ip: IpAddr) -> TestResult {
+    switch
+        .client
+        .multicast_group_delete(&group_ip)
+        .await
+        .map_err(|e| {
+            anyhow!("Failed to delete test group {}: {:?}", group_ip, e)
+        })
+        .map(|_| ())
 }
 
 /// Create an IPv4 multicast packet for testing.
@@ -401,7 +407,7 @@ async fn test_nonexisting_group() {
 
 #[tokio::test]
 #[ignore]
-async fn test_group_creation_with_validation() {
+async fn test_group_creation_with_validation() -> TestResult {
     let switch = &*get_switch().await;
 
     // Test the bifurcated multicast design:
@@ -422,7 +428,10 @@ async fn test_group_creation_with_validation() {
     )
     .await;
 
-    assert!(internal_group.underlay_group_id.is_some());
+    assert_ne!(
+        internal_group.external_group_id, internal_group.underlay_group_id,
+        "Group IDs should be different"
+    );
 
     // Test creating a group with invalid parameters (e.g., invalid VLAN ID)
     // IPv4 groups are always external
@@ -470,9 +479,22 @@ async fn test_group_creation_with_validation() {
         .expect("Should successfully create valid group")
         .into_inner();
 
+    assert_ne!(
+        created.external_group_id, created.underlay_group_id,
+        "Group IDs should be different"
+    );
+
+    assert_eq!(
+        internal_group.external_group_id, created.external_group_id,
+        "External group should reference the same external group ID as the internal group"
+    );
+
+    assert_eq!(
+        internal_group.underlay_group_id, created.underlay_group_id,
+        "Underlay group IDs should match"
+    );
+
     assert_eq!(created.group_ip, MULTICAST_TEST_IPV4_SSM);
-    assert!(created.external_group_id.is_none());
-    assert!(created.underlay_group_id.is_none());
     assert_eq!(created.tag, Some("test_valid".to_string()));
     assert_eq!(created.int_fwding.nat_target, Some(nat_target.clone()));
     assert_eq!(created.ext_fwding.vlan_id, Some(10));
@@ -484,16 +506,12 @@ async fn test_group_creation_with_validation() {
     );
     assert_eq!(created.members.len(), 0); // External groups don't have members
 
-    switch
-        .client
-        .multicast_group_delete(&created.group_ip)
-        .await
-        .expect("Failed to delete test group");
+    cleanup_test_group(switch, created.group_ip).await
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_internal_ipv6_validation() {
+async fn test_internal_ipv6_validation() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id, link_id) = switch.link_id(PhysPort(26)).unwrap();
@@ -502,7 +520,6 @@ async fn test_internal_ipv6_validation() {
     let ipv4_mapped_internal = types::MulticastGroupCreateEntry {
         group_ip: "::ffff:224.1.1.1".parse().unwrap(), // IPv4-mapped IPv6
         tag: Some("test_ipv4_mapped_internal".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -530,7 +547,6 @@ async fn test_internal_ipv6_validation() {
     let non_admin_ipv6 = types::MulticastGroupCreateEntry {
         group_ip: "ff0e::1".parse().unwrap(), // Global scope, not admin-scoped
         tag: Some("test_non_admin".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -558,7 +574,6 @@ async fn test_internal_ipv6_validation() {
     let internal_group = types::MulticastGroupCreateEntry {
         group_ip: "ff04::2".parse().unwrap(), // Admin-scoped IPv6
         tag: Some("test_admin_scoped".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -573,13 +588,15 @@ async fn test_internal_ipv6_validation() {
         .expect("Should create internal IPv6 group")
         .into_inner();
 
+    assert_ne!(
+        created.external_group_id, created.underlay_group_id,
+        "Group IDs should be different"
+    );
     assert_eq!(created.ext_fwding.vlan_id, None);
-    assert!(created.underlay_group_id.is_some());
 
     // Test update works correctly
     let update_entry = types::MulticastGroupUpdateEntry {
         tag: Some("updated_tag".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id,
             link_id,
@@ -597,12 +614,12 @@ async fn test_internal_ipv6_validation() {
     assert_eq!(updated.tag, Some("updated_tag".to_string()));
     assert_eq!(updated.ext_fwding.vlan_id, None);
 
-    cleanup_test_group(switch, created.group_ip).await;
+    cleanup_test_group(switch, created.group_ip).await
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_vlan_propagation_to_internal() {
+async fn test_vlan_propagation_to_internal() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id, link_id) = switch.link_id(PhysPort(30)).unwrap();
@@ -611,7 +628,6 @@ async fn test_vlan_propagation_to_internal() {
     let internal_group_entry = types::MulticastGroupCreateEntry {
         group_ip: "ff04::200".parse().unwrap(), // Admin-scoped IPv6
         tag: Some("test_vlan_propagation".to_string()),
-        sources: None,
         members: vec![
             types::MulticastGroupMember {
                 port_id: port_id.clone(),
@@ -633,7 +649,6 @@ async fn test_vlan_propagation_to_internal() {
         .expect("Should create admin-scoped group")
         .into_inner();
 
-    assert!(created_admin.external_group_id.is_some());
     assert_eq!(created_admin.ext_fwding.vlan_id, None); // No VLAN initially
 
     // Create external group that references the admin-scoped group
@@ -682,8 +697,10 @@ async fn test_vlan_propagation_to_internal() {
         "Admin-scoped group bitmap should have VLAN 42 from external group"
     );
 
-    cleanup_test_group(switch, created_admin.group_ip).await;
-    cleanup_test_group(switch, created_external.group_ip).await;
+    cleanup_test_group(switch, created_admin.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, created_external.group_ip).await
 }
 
 #[tokio::test]
@@ -693,7 +710,7 @@ async fn test_group_api_lifecycle() {
 
     let egress1 = PhysPort(28);
     let internal_multicast_ip = IpAddr::V6(MULTICAST_NAT_IP);
-    let underlay_group = create_test_multicast_group(
+    create_test_multicast_group(
         switch,
         internal_multicast_ip,
         Some("valid_underlay_group"),
@@ -703,8 +720,6 @@ async fn test_group_api_lifecycle() {
         None,
     )
     .await;
-
-    assert!(underlay_group.underlay_group_id.is_some());
 
     // Create IPv4 external group with NAT target referencing the underlay group
     let group_ip = IpAddr::V4(MULTICAST_TEST_IPV4);
@@ -728,14 +743,12 @@ async fn test_group_api_lifecycle() {
     let external_group_id = created.external_group_id;
 
     assert_eq!(created.group_ip, MULTICAST_TEST_IPV4);
-    assert!(created.external_group_id.is_none());
-    assert!(created.underlay_group_id.is_none());
     assert_eq!(created.tag, Some("test_lifecycle".to_string()));
     assert_eq!(created.int_fwding.nat_target, Some(nat_target.clone()));
     assert_eq!(created.ext_fwding.vlan_id, Some(vlan_id));
     assert_eq!(created.members.len(), 0); // External groups don't have members
 
-    // 3. Get all groups and verify our group is included
+    // Get all groups and verify our group is included
     let groups = switch
         .client
         .multicast_groups_list_stream(None)
@@ -748,7 +761,7 @@ async fn test_group_api_lifecycle() {
         .any(|g| g.external_group_id == external_group_id);
     assert!(found_in_list, "Created group should be in the list");
 
-    // 4. Get groups by tag
+    // Get groups by tag
     let tagged_groups = switch
         .client
         .multicast_groups_list_by_tag_stream("test_lifecycle", None)
@@ -765,7 +778,7 @@ async fn test_group_api_lifecycle() {
         .any(|g| g.external_group_id == external_group_id);
     assert!(found_by_tag, "Created group should be found by tag");
 
-    // 5. Get the specific group
+    // Get the specific group
     let group = switch
         .client
         .multicast_groups_list_stream(None)
@@ -785,7 +798,7 @@ async fn test_group_api_lifecycle() {
 
     assert_eq!(group_by_ip.external_group_id, external_group_id);
 
-    // 6. Update the group
+    // Update the group
     let updated_nat_target = types::NatTarget {
         internal_ip: MULTICAST_NAT_IP.into(),
         inner_mac: MacAddr::new(0xe0, 0xd5, 0x5e, 0x00, 0x11, 0x22).into(),
@@ -796,9 +809,7 @@ async fn test_group_api_lifecycle() {
         tag: Some("updated_lifecycle".to_string()),
         nat_target: updated_nat_target.clone(),
         vlan_id: Some(20),
-        sources: Some(vec![types::IpSrc::Exact(
-            "192.168.1.5".parse::<IpAddr>().unwrap(),
-        )]),
+        sources: None,
     };
 
     let updated = switch
@@ -809,26 +820,20 @@ async fn test_group_api_lifecycle() {
         .into_inner();
 
     assert_eq!(updated.external_group_id, external_group_id);
-    assert!(updated.underlay_group_id.is_none());
     assert_eq!(updated.tag, Some("updated_lifecycle".to_string()));
     assert_eq!(updated.int_fwding.nat_target, Some(updated_nat_target));
     assert_eq!(updated.ext_fwding.vlan_id, Some(20));
-    assert_eq!(
-        updated.sources,
-        Some(vec![types::IpSrc::Exact(
-            "192.168.1.5".parse::<IpAddr>().unwrap(),
-        )])
-    );
+    assert_eq!(updated.sources, None);
     assert_eq!(updated.members.len(), 0); // External groups don't have members
 
-    // 7. Delete the group
+    // Delete the group
     switch
         .client
         .multicast_group_delete(&group_ip)
         .await
         .expect("Should be able to delete group");
 
-    // 8. Verify group was deleted
+    // Verify group was deleted
     let result = switch
         .client
         .multicast_group_get(&group_ip)
@@ -846,7 +851,7 @@ async fn test_group_api_lifecycle() {
         _ => panic!("Expected ErrorResponse when getting a deleted group"),
     }
 
-    // 9. Verify group no longer appears in the list
+    // Verify group no longer appears in the list
     let groups_after_delete = switch
         .client
         .multicast_groups_list_stream(None)
@@ -971,19 +976,6 @@ async fn test_multicast_tagged_groups_management() {
     assert!(!remaining_ips.contains(&created1.group_ip));
     assert!(!remaining_ips.contains(&created2.group_ip));
     assert!(remaining_ips.contains(&created3.group_ip));
-
-    // Clean up the remaining group and underlay group
-    switch
-        .client
-        .multicast_group_delete(&created3.group_ip)
-        .await
-        .expect("Should delete the remaining group");
-
-    switch
-        .client
-        .multicast_group_delete(&internal_multicast_ip)
-        .await
-        .expect("Should delete the remaining group");
 }
 
 #[tokio::test]
@@ -1059,19 +1051,11 @@ async fn test_multicast_untagged_groups() {
         remaining_groups.iter().map(|g| g.group_ip).collect();
     assert!(!remaining_ips.contains(&created_untagged.group_ip));
     assert!(remaining_ips.contains(&created_tagged.group_ip));
-
-    // Clean up the remaining tagged group
-    // (NAT target group was already deleted by multicast_reset_untagged since it had no tag)
-    switch
-        .client
-        .multicast_group_delete(&created_tagged.group_ip)
-        .await
-        .expect("Should delete remaining tagged group");
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_api_internal_ipv6_bifurcated_replication() {
+async fn test_api_internal_ipv6_bifurcated_replication() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id1, link_id1) = switch.link_id(PhysPort(11)).unwrap();
@@ -1081,7 +1065,6 @@ async fn test_api_internal_ipv6_bifurcated_replication() {
     let admin_scoped_group = types::MulticastGroupCreateEntry {
         group_ip: "ff04::100".parse().unwrap(), // Admin-scoped IPv6
         tag: Some("test_bifurcated".to_string()),
-        sources: None,
         members: vec![
             types::MulticastGroupMember {
                 port_id: port_id1.clone(),
@@ -1103,24 +1086,17 @@ async fn test_api_internal_ipv6_bifurcated_replication() {
         .expect("Should create bifurcated admin-scoped group")
         .into_inner();
 
-    // Verify both group IDs are populated
-    assert!(
-        created.external_group_id.is_some(),
-        "Should have external group ID"
-    );
-    assert!(
-        created.underlay_group_id.is_some(),
-        "Should have underlay group ID"
-    );
     assert_ne!(
         created.external_group_id, created.underlay_group_id,
-        "Group IDs should be different"
+        "Internal group should have different external and underlay group IDs"
     );
-
-    // Verify group has external_group_id (replication is handled internally)
     assert!(
-        created.external_group_id.is_some(),
-        "Bifurcated group should have external_group_id"
+        created.external_group_id > 0,
+        "External group ID should be allocated and non-zero"
+    );
+    assert!(
+        created.underlay_group_id > 0,
+        "Underlay group ID should be allocated and non-zero"
     );
 
     // Verify members are preserved
@@ -1139,12 +1115,12 @@ async fn test_api_internal_ipv6_bifurcated_replication() {
     assert_eq!(external_members.len(), 1);
     assert_eq!(underlay_members.len(), 1);
 
-    cleanup_test_group(switch, created.group_ip).await;
+    cleanup_test_group(switch, created.group_ip).await
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_api_internal_ipv6_underlay_only() {
+async fn test_api_internal_ipv6_underlay_only() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id, link_id) = switch.link_id(PhysPort(11)).unwrap();
@@ -1153,7 +1129,6 @@ async fn test_api_internal_ipv6_underlay_only() {
     let underlay_only_group = types::MulticastGroupCreateEntry {
         group_ip: "ff05::200".parse().unwrap(), // Site-local admin-scoped
         tag: Some("test_underlay_only".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -1168,41 +1143,24 @@ async fn test_api_internal_ipv6_underlay_only() {
         .expect("Should create underlay-only admin-scoped group")
         .into_inner();
 
-    // Should have underlay group ID but no external group ID
-    assert!(
-        created.underlay_group_id.is_some(),
-        "Should have underlay group ID"
-    );
-    assert!(
-        created.external_group_id.is_none(),
-        "Should NOT have external group ID"
-    );
-
-    // Verify group has underlay_group_id (replication is handled internally)
-    assert!(
-        created.underlay_group_id.is_some(),
-        "Underlay-only group should have underlay_group_id"
-    );
-
     // Verify only underlay members
     assert_eq!(created.members.len(), 1);
     assert_eq!(created.members[0].direction, types::Direction::Underlay);
 
-    cleanup_test_group(switch, created.group_ip).await;
+    cleanup_test_group(switch, created.group_ip).await
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_api_internal_ipv6_external_only() {
+async fn test_api_internal_ipv6_external_only() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id, link_id) = switch.link_id(PhysPort(11)).unwrap();
 
     // Create admin-scoped IPv6 group with only external members
-    let external_only_group = types::MulticastGroupCreateEntry {
+    let external_members_only_group = types::MulticastGroupCreateEntry {
         group_ip: "ff08::300".parse().unwrap(), // Org-local admin-scoped
-        tag: Some("test_external_only".to_string()),
-        sources: None,
+        tag: Some("test_external_members_only".to_string()),
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -1212,37 +1170,21 @@ async fn test_api_internal_ipv6_external_only() {
 
     let created = switch
         .client
-        .multicast_group_create(&external_only_group)
+        .multicast_group_create(&external_members_only_group)
         .await
-        .expect("Should create external-only admin-scoped group")
+        .expect("Should create external members-only admin-scoped group")
         .into_inner();
-
-    // Should have external group ID but no underlay group ID
-    assert!(
-        created.external_group_id.is_some(),
-        "Should have external group ID"
-    );
-    assert!(
-        created.underlay_group_id.is_none(),
-        "Should NOT have underlay group ID"
-    );
-
-    // Verify group has external_group_id (replication is handled internally)
-    assert!(
-        created.external_group_id.is_some(),
-        "External-only group should have external_group_id"
-    );
 
     // Verify only external members
     assert_eq!(created.members.len(), 1);
     assert_eq!(created.members[0].direction, types::Direction::External);
 
-    cleanup_test_group(switch, created.group_ip).await;
+    cleanup_test_group(switch, created.group_ip).await
 }
 
 #[tokio::test]
 #[ignore]
-async fn test_api_invalid_combinations() {
+async fn test_api_invalid_combinations() -> TestResult {
     let switch = &*get_switch().await;
 
     // First create the internal admin-scoped group that will be the NAT target
@@ -1275,9 +1217,6 @@ async fn test_api_invalid_combinations() {
         .expect("IPv4 external group should be created")
         .into_inner();
 
-    // But it should not have underlay group ID or replication info
-    assert!(created_ipv4.underlay_group_id.is_none());
-
     // Non-admin-scoped IPv6 should use external API
     let non_admin_ipv6 = types::MulticastGroupCreateExternalEntry {
         group_ip: "ff0e::400".parse().unwrap(), // Global scope, not admin-scoped
@@ -1293,9 +1232,6 @@ async fn test_api_invalid_combinations() {
         .await
         .expect("Non-admin-scoped IPv6 should use external API")
         .into_inner();
-
-    // Should not have underlay group ID or replication info
-    assert!(created_non_admin.underlay_group_id.is_none());
 
     // Admin-scoped IPv6 with underlay members should fail via external API
     let admin_scoped_external_entry =
@@ -1325,9 +1261,13 @@ async fn test_api_invalid_combinations() {
         ),
     }
 
-    cleanup_test_group(switch, created_ipv4.group_ip).await;
-    cleanup_test_group(switch, created_non_admin.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
+    cleanup_test_group(switch, created_ipv4.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, created_non_admin.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -1418,7 +1358,7 @@ async fn test_ipv4_multicast_invalid_destination_mac() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1442,10 +1382,10 @@ async fn test_ipv4_multicast_invalid_destination_mac() -> TestResult {
     .unwrap();
 
     // Cleanup: Remove both external IPv4 group and underlay IPv6 group
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -1514,7 +1454,7 @@ async fn test_ipv6_multicast_invalid_destination_mac() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1537,9 +1477,7 @@ async fn test_ipv6_multicast_invalid_destination_mac() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip).await
 }
 
 #[tokio::test]
@@ -1607,7 +1545,7 @@ async fn test_multicast_ttl_zero() -> TestResult {
     let ctr_baseline =
         switch.get_counter("ipv4_ttl_invalid", None).await.unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1619,10 +1557,10 @@ async fn test_multicast_ttl_zero() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -1690,7 +1628,7 @@ async fn test_multicast_ttl_one() -> TestResult {
     let ctr_baseline =
         switch.get_counter("ipv4_ttl_invalid", None).await.unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1702,10 +1640,10 @@ async fn test_multicast_ttl_one() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -1719,7 +1657,7 @@ async fn test_ipv4_multicast_basic_replication_nat_ingress() -> TestResult {
     let egress2 = PhysPort(17);
     let egress3 = PhysPort(19);
 
-    //  Create admin-scoped IPv6 multicast group for underlay replication
+    // Create admin-scoped IPv6 multicast group for underlay replication
     // This handles the actual packet replication within the rack infrastructure
     // after NAT ingress processing
     let internal_multicast_ip = IpAddr::V6(MULTICAST_NAT_IP);
@@ -1826,7 +1764,7 @@ async fn test_ipv4_multicast_basic_replication_nat_ingress() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1838,9 +1776,7 @@ async fn test_ipv4_multicast_basic_replication_nat_ingress() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip).await
 }
 
 #[tokio::test]
@@ -1964,7 +1900,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_external_members(
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -1976,10 +1912,10 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_external_members(
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await
 }
 
 #[tokio::test]
@@ -2101,7 +2037,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_members(
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2113,10 +2049,10 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_members(
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await
 }
 
 #[tokio::test]
@@ -2256,7 +2192,7 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_and_external_membe
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2268,10 +2204,10 @@ async fn test_encapped_multicast_geneve_mcast_tag_to_underlay_and_external_membe
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, MULTICAST_NAT_IP.into()).await
 }
 
 #[tokio::test]
@@ -2336,7 +2272,7 @@ async fn test_ipv4_multicast_drops_ingress_is_egress_port() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2348,10 +2284,10 @@ async fn test_ipv4_multicast_drops_ingress_is_egress_port() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -2419,9 +2355,11 @@ async fn test_ipv6_multicast_hop_limit_zero() -> TestResult {
     let ctr_baseline =
         switch.get_counter("ipv6_ttl_invalid", None).await.unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
 
     check_counter_incremented(
         switch,
@@ -2433,7 +2371,7 @@ async fn test_ipv6_multicast_hop_limit_zero() -> TestResult {
     .await
     .unwrap();
 
-    result
+    Ok(())
 }
 
 #[tokio::test]
@@ -2505,7 +2443,7 @@ async fn test_ipv6_multicast_hop_limit_one() -> TestResult {
     let ctr_baseline =
         switch.get_counter("ipv6_ttl_invalid", None).await.unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2517,9 +2455,7 @@ async fn test_ipv6_multicast_hop_limit_one() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip).await
 }
 
 #[tokio::test]
@@ -2605,7 +2541,7 @@ async fn test_ipv6_multicast_basic_replication_nat_ingress() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2617,9 +2553,7 @@ async fn test_ipv6_multicast_basic_replication_nat_ingress() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip).await
 }
 
 #[tokio::test]
@@ -2731,7 +2665,7 @@ async fn test_ipv4_multicast_source_filtering_exact_match() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(test_pkts, expected_pkts);
+    switch.packet_test(test_pkts, expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2743,10 +2677,10 @@ async fn test_ipv4_multicast_source_filtering_exact_match() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -2898,7 +2832,7 @@ async fn test_ipv4_multicast_source_filtering_prefix_match() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(test_pkts, expected_pkts);
+    switch.packet_test(test_pkts, expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -2910,10 +2844,10 @@ async fn test_ipv4_multicast_source_filtering_prefix_match() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -3070,7 +3004,7 @@ async fn test_ipv6_multicast_multiple_source_filtering() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(test_pkts, expected_pkts);
+    switch.packet_test(test_pkts, expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -3082,10 +3016,10 @@ async fn test_ipv6_multicast_multiple_source_filtering() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -3180,7 +3114,7 @@ async fn test_multicast_dynamic_membership() -> TestResult {
     let external_update_entry = types::MulticastGroupUpdateExternalEntry {
         tag: None,
         nat_target: create_nat_target_ipv4(), // Keep the same NAT target
-        vlan_id: None,
+        vlan_id: Some(10), // Test with VLAN like reference test
         sources: None,
     };
 
@@ -3213,7 +3147,6 @@ async fn test_multicast_dynamic_membership() -> TestResult {
                 direction: types::Direction::External,
             },
         ],
-        sources: None,
     };
 
     switch
@@ -3254,12 +3187,14 @@ async fn test_multicast_dynamic_membership() -> TestResult {
         },
     ];
 
-    let result2 = switch.packet_test(vec![test_pkt_new], expected_pkts_new);
+    switch
+        .packet_test(vec![test_pkt_new], expected_pkts_new)
+        .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result2
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -3453,13 +3388,15 @@ async fn test_multicast_multiple_groups() -> TestResult {
         },
     ];
 
-    let result = switch.packet_test(test_pkts, expected_pkts);
+    switch.packet_test(test_pkts, expected_pkts).unwrap();
 
-    cleanup_test_group(switch, created_group1.group_ip).await;
-    cleanup_test_group(switch, created_group2.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group1.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, created_group2.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -3522,7 +3459,6 @@ async fn test_multicast_reset_all_tables() -> TestResult {
     let group_entry2b = types::MulticastGroupCreateEntry {
         group_ip: Ipv6Addr::new(0xff04, 0, 0, 0, 0, 0, 0, 2),
         tag: Some("test_reset_all_2b".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: switch.link_id(egress1).unwrap().0,
             link_id: switch.link_id(egress1).unwrap().1,
@@ -3786,14 +3722,13 @@ async fn test_multicast_vlan_translation_not_possible() -> TestResult {
     let ingress = PhysPort(10);
 
     //  Create admin-scoped IPv6 underlay group that will handle actual replication
-    // Must have at least one member to satisfy validation requirements
     let egress1 = PhysPort(15);
     let internal_multicast_ip = IpAddr::V6(MULTICAST_NAT_IP);
     create_test_multicast_group(
         switch,
         internal_multicast_ip,
         Some("test_vlan_underlay"),
-        &[(egress1, types::Direction::External)], // Need at least one member for admin-scoped groups
+        &[(egress1, types::Direction::External)],
         None,
         false, // Admin-scoped groups don't need NAT targets
         None,
@@ -3843,12 +3778,12 @@ async fn test_multicast_vlan_translation_not_possible() -> TestResult {
     // is not possible for multicast packets
     let expected_pkts = vec![];
 
-    let result = switch.packet_test(vec![test_pkt], expected_pkts);
+    switch.packet_test(vec![test_pkt], expected_pkts).unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -3965,7 +3900,7 @@ async fn test_multicast_multiple_packets() -> TestResult {
         .await
         .unwrap();
 
-    let result = switch.packet_test(test_pkts, expected_pkts);
+    switch.packet_test(test_pkts, expected_pkts).unwrap();
 
     check_counter_incremented(
         switch,
@@ -3977,10 +3912,10 @@ async fn test_multicast_multiple_packets() -> TestResult {
     .await
     .unwrap();
 
-    cleanup_test_group(switch, created_group.group_ip).await;
-    cleanup_test_group(switch, internal_multicast_ip).await;
-
-    result
+    cleanup_test_group(switch, created_group.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, internal_multicast_ip).await
 }
 
 #[tokio::test]
@@ -4076,7 +4011,7 @@ async fn test_multicast_no_group_configured() -> TestResult {
 
 #[tokio::test]
 #[ignore]
-async fn test_external_group_nat_target_validation() {
+async fn test_external_group_nat_target_validation() -> TestResult {
     let switch = &*get_switch().await;
 
     let (port_id, link_id) = switch.link_id(PhysPort(11)).unwrap();
@@ -4113,7 +4048,6 @@ async fn test_external_group_nat_target_validation() {
     let admin_scoped_group = types::MulticastGroupCreateEntry {
         group_ip: "ff04::1".parse().unwrap(), // Admin-scoped IPv6
         tag: Some("test_admin_scoped".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: port_id.clone(),
             link_id,
@@ -4128,7 +4062,23 @@ async fn test_external_group_nat_target_validation() {
         .expect("Should create admin-scoped group")
         .into_inner();
 
-    assert!(created_admin.underlay_group_id.is_some());
+    // Test with NAT: internal group created first with no NAT members gets IDs allocated
+    assert_ne!(
+        created_admin.external_group_id, created_admin.underlay_group_id,
+        "Internal group should have different external and underlay group IDs"
+    );
+    assert!(
+        created_admin.external_group_id > 0,
+        "Internal group should have allocated external group ID"
+    );
+    assert!(
+        created_admin.underlay_group_id > 0,
+        "Internal group should have allocated underlay group ID"
+    );
+    assert!(
+        created_admin.int_fwding.nat_target.is_none(),
+        "Internal group has no NAT target (it gets referenced by external groups)"
+    );
 
     // Test 3: Now create external group with valid NAT target
     let valid_nat_target = types::NatTarget {
@@ -4140,7 +4090,7 @@ async fn test_external_group_nat_target_validation() {
     let group_with_valid_nat = types::MulticastGroupCreateExternalEntry {
         group_ip: IpAddr::V4("224.1.0.102".parse().unwrap()),
         tag: Some("test_valid_nat".to_string()),
-        nat_target: valid_nat_target,
+        nat_target: valid_nat_target.clone(),
         vlan_id: Some(10),
         sources: None,
     };
@@ -4152,24 +4102,46 @@ async fn test_external_group_nat_target_validation() {
         .expect("Should create external group with valid NAT target")
         .into_inner();
 
-    // External groups created via external API don't have external_group_id unless
-    // there are external members in the referenced admin-scoped group
-    assert!(
-        created_external.external_group_id.is_none(),
-        "External API groups shouldn't have external_group_id without external members"
+    // External group should share the same IDs as the internal group it references
+    assert_eq!(
+        created_external.external_group_id, created_admin.external_group_id,
+        "External group should reuse the internal group's external_group_id"
     );
-    assert!(
-        created_external.underlay_group_id.is_none(),
-        "External group should not have underlay_group_id"
+    assert_eq!(
+        created_external.underlay_group_id, created_admin.underlay_group_id,
+        "External group should reuse the internal group's underlay_group_id"
     );
+
     assert_eq!(
         created_external.members.len(),
         0,
         "External group should have no members"
     );
 
-    cleanup_test_group(switch, created_admin.group_ip).await;
-    cleanup_test_group(switch, created_external.group_ip).await;
+    // Verify NAT target configuration
+    assert!(
+        created_admin.int_fwding.nat_target.is_none(),
+        "Internal group should have no NAT target"
+    );
+    assert!(
+        created_external.int_fwding.nat_target.is_some(),
+        "External group should have NAT target pointing to internal group"
+    );
+    assert_eq!(
+        created_external
+            .int_fwding
+            .nat_target
+            .as_ref()
+            .unwrap()
+            .internal_ip,
+        valid_nat_target.internal_ip,
+        "External group's NAT target should point to the correct internal IP"
+    );
+
+    cleanup_test_group(switch, created_admin.group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(switch, created_external.group_ip).await
 }
 
 #[tokio::test]
@@ -4184,7 +4156,6 @@ async fn test_ipv6_multicast_scope_validation() {
     let admin_local_group = types::MulticastGroupCreateEntry {
         group_ip: "ff04::100".parse().unwrap(),
         tag: Some("test_admin_local".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: egress_port.clone(),
             link_id: egress_link,
@@ -4205,7 +4176,6 @@ async fn test_ipv6_multicast_scope_validation() {
     let site_local_group = types::MulticastGroupCreateEntry {
         group_ip: "ff05::200".parse().unwrap(),
         tag: Some("test_site_local".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: egress_port.clone(),
             link_id: egress_link,
@@ -4226,7 +4196,6 @@ async fn test_ipv6_multicast_scope_validation() {
     let org_local_group = types::MulticastGroupCreateEntry {
         group_ip: "ff08::300".parse().unwrap(),
         tag: Some("test_org_local".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: egress_port.clone(),
             link_id: egress_link,
@@ -4245,7 +4214,6 @@ async fn test_ipv6_multicast_scope_validation() {
     let global_scope_group = types::MulticastGroupCreateEntry {
         group_ip: "ff0e::400".parse().unwrap(),
         tag: Some("test_global".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: egress_port.clone(),
             link_id: egress_link,
@@ -4274,7 +4242,6 @@ async fn test_ipv6_multicast_scope_validation() {
     let admin_target_group = types::MulticastGroupCreateEntry {
         group_ip: "ff04::1000".parse().unwrap(),
         tag: Some("test_target".to_string()),
-        sources: None,
         members: vec![types::MulticastGroupMember {
             port_id: egress_port.clone(),
             link_id: egress_link,
@@ -4345,7 +4312,7 @@ async fn test_ipv6_multicast_scope_validation() {
 
 #[tokio::test]
 #[ignore]
-async fn test_multicast_group_id_recycling() {
+async fn test_multicast_group_id_recycling() -> TestResult {
     let switch = &*get_switch().await;
 
     // Use admin-scoped IPv6 addresses that get group IDs assigned
@@ -4365,9 +4332,6 @@ async fn test_multicast_group_id_recycling() {
     )
     .await;
 
-    let group1_external_id = group1.external_group_id;
-    assert!(group1_external_id.is_some());
-
     // Create second group and capture its group IDs
     let group2 = create_test_multicast_group(
         switch,
@@ -4380,9 +4344,7 @@ async fn test_multicast_group_id_recycling() {
     )
     .await;
 
-    let group2_external_id = group2.external_group_id;
-    assert!(group2_external_id.is_some());
-    assert_ne!(group1_external_id, group2_external_id);
+    assert_ne!(group1.external_group_id, group2.external_group_id);
 
     // Delete the first group
     switch
@@ -4415,13 +4377,10 @@ async fn test_multicast_group_id_recycling() {
     )
     .await;
 
-    let group3_external_id = group3.external_group_id;
-    assert!(group3_external_id.is_some());
-
     // Verify that ID recycling is working - group3 should get an ID that was
     // previously used
     assert_ne!(
-        group2_external_id, group3_external_id,
+        group2.external_group_id, group3.external_group_id,
         "Third group should get a different ID than the active second group"
     );
 
@@ -4456,17 +4415,1509 @@ async fn test_multicast_group_id_recycling() {
     )
     .await;
 
-    let group4_external_id = group4.external_group_id;
-    assert!(group4_external_id.is_some());
-
-    // Group4 should reuse group2's recently freed ID due to stack-like
-    // allocation
+    // Group4 should reuse Group2's underlay ID (LIFO: underlay ID was allocated last, returned first)
     assert_eq!(
-        group2_external_id, group4_external_id,
-        "Fourth group should reuse second group's recycled ID"
+        group2.underlay_group_id, group4.external_group_id,
+        "Fourth group should reuse Group2's underlay ID due to LIFO recycling"
     );
 
-    // Cleanup - clean up remaining active groups
-    cleanup_test_group(switch, group3_ip).await;
-    cleanup_test_group(switch, group4_ip).await;
+    cleanup_test_group(switch, group3_ip).await.unwrap();
+    cleanup_test_group(switch, group4_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_empty_then_add_members_ipv6() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 100));
+    let external_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 100));
+
+    // Create internal admin-scoped group (empty, no members)
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("empty_internal_ipv6_group"),
+        &[],   // No members (Omicron setup)
+        None,  // No VLAN
+        false, // No NAT needed for internal groups
+        None,
+    )
+    .await;
+
+    // Create external group that references the internal group (empty, no members)
+    let nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x00, 0x00, 0x01).into(),
+        vni: 100.into(),
+    };
+
+    let external_group = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        tag: Some("empty_external_ipv6_group".to_string()),
+        nat_target: nat_target.clone(),
+        vlan_id: Some(10), // Test with VLAN like reference test
+        sources: None,
+    };
+
+    switch
+        .client
+        .multicast_group_create_external(&external_group)
+        .await
+        .expect("Should create empty external IPv6 group");
+
+    // Verify both groups have no members initially
+    let groups = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list groups");
+
+    let internal_group = groups
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the created internal group");
+
+    let external_group = groups
+        .iter()
+        .find(|g| g.group_ip == external_group_ip)
+        .expect("Should find the created external group");
+
+    assert!(
+        internal_group.members.is_empty(),
+        "Empty internal group should have no members initially"
+    );
+    assert!(
+        external_group.members.is_empty(),
+        "Empty external group should have no members initially"
+    );
+
+    // Test: Send Geneve packet targeting internal group when empty - should have no replication
+    let ingress_port = PhysPort(10);
+    let src_ip = "2001:db8::1";
+    let src_port = 3333;
+    let dst_port = 4444;
+
+    // Create the original IPv6 packet payload
+    let src_mac = switch.get_port_mac(ingress_port).unwrap();
+    let og_pkt = create_ipv6_multicast_packet(
+        external_group_ip,
+        src_mac,
+        src_ip,
+        src_port,
+        dst_port,
+    );
+
+    // Create Geneve packet targeting the internal group (like test_encapped_multicast_geneve_mcast_tag_to_underlay_members)
+    let eth_hdr_len = 14;
+    let payload = og_pkt.deparse().unwrap()[eth_hdr_len..].to_vec();
+    let geneve_pkt = common::gen_geneve_packet_with_mcast_tag(
+        Endpoint::parse(
+            GIMLET_MAC,
+            &GIMLET_IP.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        Endpoint::parse(
+            &derive_ipv6_mcast_mac(&nat_target.internal_ip).to_string(),
+            &nat_target.internal_ip.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV6,
+        nat_target.vni.clone().into(),
+        2, // mcast_tag = 2 (allows both external and underlay replication)
+        &payload,
+    );
+
+    let send = TestPacket {
+        packet: Arc::new(geneve_pkt.clone()),
+        port: ingress_port,
+    };
+
+    // Verify no packets are replicated when group is empty
+    switch.packet_test(vec![send], Vec::new())?;
+
+    // Verify bitmap table is initially empty for both group IDs
+    let bitmap_table_initial = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table initially");
+    // Should have no bitmap entries when groups are empty
+    assert!(
+        bitmap_table_initial.entries.is_empty(),
+        "Bitmap table should be empty when groups have no members"
+    );
+
+    // Test: Add members to the internal group using update (mix of External and Underlay)
+    let egress1 = PhysPort(15);
+    let egress2 = PhysPort(17);
+    let egress3 = PhysPort(18);
+    let (port_id1, link_id1) = switch.link_id(egress1).unwrap();
+    let (port_id2, link_id2) = switch.link_id(egress2).unwrap();
+    let (port_id3, link_id3) = switch.link_id(egress3).unwrap();
+
+    let external_member1 = types::MulticastGroupMember {
+        port_id: port_id1,
+        link_id: link_id1,
+        direction: types::Direction::External,
+    };
+
+    let external_member2 = types::MulticastGroupMember {
+        port_id: port_id2,
+        link_id: link_id2,
+        direction: types::Direction::External,
+    };
+
+    let underlay_member = types::MulticastGroupMember {
+        port_id: port_id3,
+        link_id: link_id3,
+        direction: types::Direction::Underlay,
+    };
+
+    // Update the internal group to add members (2 external, 1 underlay)
+    // Meaning: two decap/port-bitmap members.
+    let update_entry = types::MulticastGroupUpdateEntry {
+        tag: Some("empty_internal_ipv6_group".to_string()),
+        members: vec![external_member1, external_member2, underlay_member],
+    };
+
+    switch
+        .client
+        .multicast_group_update(&internal_group_ip, &update_entry)
+        .await
+        .expect("Should update internal group with members");
+
+    // Verify members were added
+    let updated_groups = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list updated groups");
+
+    let updated_internal = updated_groups
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the updated internal group");
+
+    assert_eq!(
+        updated_internal.members.len(),
+        3,
+        "Internal group should now have 3 members (2 external, 1 underlay)"
+    );
+
+    // Test: Send Geneve packet again targeting internal group -
+    // This should now replicate to all 3 members (2 external + 1 underlay)
+    let og_pkt2 = create_ipv6_multicast_packet(
+        external_group_ip,
+        src_mac,
+        "2001:db8::2", // Different source IP to differentiate packets
+        3334,
+        4445,
+    );
+
+    // Test packet for use in final assertion
+    let to_send_final = og_pkt2.clone();
+
+    // Create Geneve packet for the underlay to underlay replication, no decap
+    let payload2 = og_pkt2.deparse().unwrap()[eth_hdr_len..].to_vec();
+    let to_send_again = common::gen_geneve_packet_with_mcast_tag(
+        Endpoint::parse(
+            GIMLET_MAC,
+            &GIMLET_IP.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        Endpoint::parse(
+            &derive_ipv6_mcast_mac(&nat_target.internal_ip).to_string(),
+            &nat_target.internal_ip.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV6,
+        nat_target.vni.clone().into(),
+        2, // mcast_tag = 2 (allows both external and underlay replication)
+        &payload2,
+    );
+
+    // Create expected packets for all three egress ports
+    let expected1 = prepare_expected_pkt(
+        switch,
+        &og_pkt2,
+        Some(10), // VLAN should come from external group
+        None,     // No NAT target for external members
+        Some(egress1),
+    );
+
+    let expected2 = prepare_expected_pkt(
+        switch,
+        &og_pkt2,
+        Some(10), // VLAN should come from external group
+        None,     // No NAT target for external members (like reference test)
+        Some(egress2),
+    );
+
+    // Underlay member gets the Geneve packet unchanged
+    let expected3 = prepare_expected_pkt(
+        switch,
+        &to_send_again,
+        None, // No VLAN
+        None, // No NAT target for underlay member
+        Some(egress3),
+    );
+
+    let send_again = TestPacket {
+        packet: Arc::new(to_send_again),
+        port: ingress_port,
+    };
+
+    let expected_pkts = vec![
+        TestPacket {
+            packet: Arc::new(expected1),
+            port: egress1,
+        },
+        TestPacket {
+            packet: Arc::new(expected2),
+            port: egress2,
+        },
+        TestPacket {
+            packet: Arc::new(expected3),
+            port: egress3,
+        },
+    ];
+
+    // Verify packets are now replicated to all 3 members (2 external + 1 underlay)
+    switch.packet_test(vec![send_again], expected_pkts)?;
+
+    // Verify bitmap table now has entry for external group ID only (1 entry with bitmap of 2 ports)
+    let bitmap_table_with_members = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table with members");
+    assert_eq!(
+        bitmap_table_with_members.entries.len(),
+        1,
+        "Bitmap table should have entry for external group ID when group has members"
+    );
+
+    // Test: Update internal group back to empty (remove all members)
+    let empty_update_entry = types::MulticastGroupUpdateEntry {
+        tag: None,
+        members: vec![], // Remove all members
+    };
+
+    switch
+        .client
+        .multicast_group_update(&internal_group_ip, &empty_update_entry)
+        .await
+        .expect("Should update internal group back to empty");
+
+    // Verify the group is now empty
+    let groups_after_empty = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list groups after emptying");
+
+    let empty_internal = groups_after_empty
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the internal group");
+
+    assert_eq!(
+        empty_internal.members.len(),
+        0,
+        "Internal group should be empty again"
+    );
+
+    // Verify bitmap table is empty again after removing all members
+    let bitmap_table_final = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table after emptying");
+    // Should have no bitmap entries when group is empty again
+    assert!(
+        bitmap_table_final.entries.is_empty(),
+        "Bitmap table should be empty again when group has no members"
+    );
+
+    let send_final = TestPacket {
+        packet: Arc::new(to_send_final),
+        port: ingress_port,
+    };
+
+    // Should only see packet on ingress, no replication to egress ports
+    let expected_final = vec![];
+
+    switch.packet_test(vec![send_final], expected_final)?;
+
+    cleanup_test_group(&switch, external_group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_empty_then_add_members_ipv4() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 101));
+    let external_group_ip = IpAddr::V4(Ipv4Addr::new(224, 1, 2, 100));
+
+    // Create internal admin-scoped group (empty, no members)
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("empty_internal_ipv4_nat_target"),
+        &[],   // No members
+        None,  // No VLAN
+        false, // No NAT needed for internal groups
+        None,
+    )
+    .await;
+
+    // Create external group that references the internal group (empty, no members)
+    let nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x02, 0x64).into(),
+        vni: 100.into(),
+    };
+
+    let external_group = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        tag: Some("empty_external_ipv4_group".to_string()),
+        nat_target: nat_target.clone(),
+        vlan_id: Some(10), // Test with VLAN like reference test
+        sources: None,
+    };
+
+    switch
+        .client
+        .multicast_group_create_external(&external_group)
+        .await
+        .expect("Should create empty external IPv4 group");
+
+    // Verify both groups have no members initially
+    let groups = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list groups");
+
+    let internal_group = groups
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the created internal group");
+
+    let external_group = groups
+        .iter()
+        .find(|g| g.group_ip == external_group_ip)
+        .expect("Should find the created external group");
+
+    assert!(
+        internal_group.members.is_empty(),
+        "Empty internal group should have no members initially"
+    );
+    assert!(
+        external_group.members.is_empty(),
+        "Empty external group should have no members initially"
+    );
+
+    // Test: Send Geneve packet targeting internal group when empty - should have no replication
+    let ingress_port = PhysPort(10);
+    let src_ip = "192.168.1.10";
+    let src_port = 3333;
+    let dst_port = 4444;
+
+    // Create the original IPv4 packet payload
+    let src_mac = switch.get_port_mac(ingress_port).unwrap();
+    let og_pkt = create_ipv4_multicast_packet(
+        external_group_ip,
+        src_mac,
+        src_ip,
+        src_port,
+        dst_port,
+    );
+
+    // Create Geneve packet targeting the internal group (like test_encapped_multicast_geneve_mcast_tag_to_underlay_members)
+    let eth_hdr_len = 14;
+    let payload = og_pkt.deparse().unwrap()[eth_hdr_len..].to_vec();
+    let geneve_pkt = common::gen_geneve_packet_with_mcast_tag(
+        Endpoint::parse(
+            GIMLET_MAC,
+            &GIMLET_IP.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        Endpoint::parse(
+            &derive_ipv6_mcast_mac(&nat_target.internal_ip).to_string(),
+            &nat_target.internal_ip.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV4,
+        nat_target.vni.clone().into(),
+        2, // mcast_tag = 2 (allows both external and underlay replication)
+        &payload,
+    );
+
+    let send = TestPacket {
+        packet: Arc::new(geneve_pkt.clone()),
+        port: ingress_port,
+    };
+
+    // Verify no packets are replicated when group is empty
+    switch.packet_test(vec![send], Vec::new())?;
+
+    // Verify bitmap table is initially empty for both group IDs
+    let bitmap_table_initial = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table initially");
+    // Should have no bitmap entries when groups are empty
+    assert!(
+        bitmap_table_initial.entries.is_empty(),
+        "Bitmap table should be empty when groups have no members"
+    );
+
+    // Test: Add members to the internal group using update (mix of External and Underlay)
+    let egress1 = PhysPort(15);
+    let egress2 = PhysPort(17);
+    let egress3 = PhysPort(18);
+    let (port_id1, link_id1) = switch.link_id(egress1).unwrap();
+    let (port_id2, link_id2) = switch.link_id(egress2).unwrap();
+    let (port_id3, link_id3) = switch.link_id(egress3).unwrap();
+
+    let external_member1 = types::MulticastGroupMember {
+        port_id: port_id1,
+        link_id: link_id1,
+        direction: types::Direction::External,
+    };
+
+    let external_member2 = types::MulticastGroupMember {
+        port_id: port_id2,
+        link_id: link_id2,
+        direction: types::Direction::External,
+    };
+
+    let underlay_member = types::MulticastGroupMember {
+        port_id: port_id3,
+        link_id: link_id3,
+        direction: types::Direction::Underlay,
+    };
+
+    // Update the internal group to add members (2 external, 1 underlay)
+    let update_entry = types::MulticastGroupUpdateEntry {
+        tag: Some("empty_internal_ipv4_nat_target".to_string()),
+        members: vec![external_member1, external_member2, underlay_member],
+    };
+
+    switch
+        .client
+        .multicast_group_update(&internal_group_ip, &update_entry)
+        .await
+        .expect("Should update internal group with members");
+
+    // Verify members were added to the internal group
+    let updated_groups = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list updated groups");
+
+    let updated_internal = updated_groups
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the updated internal group");
+
+    assert_eq!(
+        updated_internal.members.len(),
+        3,
+        "Internal group should now have 3 members (2 external, 1 underlay)"
+    );
+
+    // Test: Send Geneve packet again targeting internal group
+    // This should now replicate to all 3 members
+    let og_pkt2 = create_ipv4_multicast_packet(
+        external_group_ip,
+        src_mac,
+        "10.1.1.2",
+        1235,
+        5679,
+    );
+
+    // Test packet for use in final assertion
+    let to_send_final = og_pkt2.clone();
+
+    // Create Geneve packet for the second test
+    let payload2 = og_pkt2.deparse().unwrap()[eth_hdr_len..].to_vec();
+    let test_packet2 = common::gen_geneve_packet_with_mcast_tag(
+        Endpoint::parse(
+            GIMLET_MAC,
+            &GIMLET_IP.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        Endpoint::parse(
+            &derive_ipv6_mcast_mac(&nat_target.internal_ip).to_string(),
+            &nat_target.internal_ip.to_string(),
+            geneve::GENEVE_UDP_PORT,
+        )
+        .unwrap(),
+        eth::ETHER_IPV4,
+        nat_target.vni.clone().into(),
+        2, // mcast_tag = 2 (allows both external and underlay replication)
+        &payload2,
+    );
+
+    // Create expected packets for all three egress ports
+    let expected1 = prepare_expected_pkt(
+        switch,
+        &og_pkt2,
+        Some(10), // VLAN should come from external group
+        None,     // No NAT target for external members (like reference test)
+        Some(egress1),
+    );
+
+    let expected2 = prepare_expected_pkt(
+        switch,
+        &og_pkt2,
+        Some(10), // VLAN should come from external group
+        None,     // No NAT target for external members (like reference test)
+        Some(egress2),
+    );
+
+    // Underlay member gets the Geneve packet unchanged (like test_encapped_multicast_geneve_mcast_tag_to_underlay_members)
+    let expected3 = prepare_expected_pkt(
+        switch,
+        &test_packet2,
+        None, // No VLAN
+        None, // No NAT target for underlay member
+        Some(egress3),
+    );
+
+    let send_again = TestPacket {
+        packet: Arc::new(test_packet2),
+        port: ingress_port,
+    };
+
+    let expected_pkts = vec![
+        TestPacket {
+            packet: Arc::new(expected1),
+            port: egress1,
+        },
+        TestPacket {
+            packet: Arc::new(expected2),
+            port: egress2,
+        },
+        TestPacket {
+            packet: Arc::new(expected3),
+            port: egress3,
+        },
+    ];
+
+    // Verify packets are now replicated to all 3 members via NAT target
+    switch.packet_test(vec![send_again], expected_pkts)?;
+
+    // Verify bitmap table now has entry for external group ID only (underlay doesn't need decap bitmap)
+    let bitmap_table_with_members = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table with members");
+    // Should have bitmap entry for external group ID only (underlay doesn't need decap bitmap)
+    assert_eq!(
+        bitmap_table_with_members.entries.len(),
+        1,
+        "Bitmap table should have entry for external group ID when group has members"
+    );
+
+    // Test: Update internal group back to empty (remove all members)
+    let empty_update_entry = types::MulticastGroupUpdateEntry {
+        tag: None,
+        members: vec![], // Remove all members
+    };
+
+    switch
+        .client
+        .multicast_group_update(&internal_group_ip, &empty_update_entry)
+        .await
+        .expect("Should update internal group back to empty");
+
+    // Verify the group is now empty
+    let groups_after_empty = switch
+        .client
+        .multicast_groups_list_stream(None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Should be able to list groups after emptying");
+
+    let empty_internal = groups_after_empty
+        .iter()
+        .find(|g| g.group_ip == internal_group_ip)
+        .expect("Should find the internal group");
+
+    assert_eq!(
+        empty_internal.members.len(),
+        0,
+        "Internal group should be empty again"
+    );
+
+    // Verify bitmap table is empty again after removing all members
+    let bitmap_table_final = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table after emptying");
+    // Should have no bitmap entries when group is empty again
+    assert!(
+        bitmap_table_final.entries.is_empty(),
+        "Bitmap table should be empty again when group has no members"
+    );
+
+    // Test: Send packet again - should now only reach ingress (no replication)
+    let send_final = TestPacket {
+        packet: Arc::new(to_send_final),
+        port: ingress_port,
+    };
+
+    // Should only see packet on ingress, no replication to egress ports
+    let expected_final = vec![];
+
+    switch.packet_test(vec![send_final], expected_final)?;
+
+    cleanup_test_group(&switch, external_group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+// =============================================================================
+// ROLLBACK TESTS
+// =============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_external_group_creation_failure() -> TestResult
+{
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 102));
+    let external_group_ip = IpAddr::V4(Ipv4Addr::new(224, 1, 2, 102));
+
+    // Create internal group with members first
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("rollback_test_internal"),
+        &[
+            (PhysPort(15), types::Direction::External),
+            (PhysPort(17), types::Direction::Underlay),
+        ],
+        None, // No VLAN
+        false,
+        None,
+    )
+    .await;
+
+    // Get initial state - should have internal group but no external group
+    let initial_groups = switch
+        .client
+        .multicast_groups_list(None, None)
+        .await
+        .expect("Should be able to list initial groups");
+    let initial_internal_count = initial_groups.items.len();
+
+    // Get initial table states
+    let initial_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table");
+    let initial_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table");
+    let initial_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table");
+
+    // Attempt to create external group with invalid data that will cause failure
+    // Use an extremely large VNI that should cause table issues
+    let nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x02, 0x66).into(),
+        vni: u32::MAX.into(), // This should be problematic
+    };
+
+    let external_entry = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        sources: None,
+        vlan_id: Some(10),
+        nat_target,
+        tag: None,
+    };
+
+    // This should fail and trigger rollback
+    let result = switch
+        .client
+        .multicast_group_create_external(&external_entry)
+        .await;
+
+    // Verify the creation failed
+    assert!(
+        result.is_err(),
+        "External group creation should have failed"
+    );
+
+    // Verify rollback worked - check that no state was left behind
+
+    // Group count should be unchanged
+    let post_failure_groups = switch
+        .client
+        .multicast_groups_list(None, None)
+        .await
+        .expect("Should be able to list groups after rollback");
+    assert_eq!(
+        post_failure_groups.items.len(),
+        initial_internal_count,
+        "Group count should be unchanged after rollback"
+    );
+
+    // No external group should exist
+    let external_groups: Vec<_> = post_failure_groups
+        .items
+        .iter()
+        .filter(|g| g.group_ip == external_group_ip)
+        .collect();
+
+    assert!(
+        external_groups.is_empty(),
+        "No external group should exist after rollback"
+    );
+
+    // Table states should be unchanged
+    let post_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table");
+
+    assert_eq!(
+        post_route_table.entries.len(),
+        initial_route_table.entries.len(),
+        "Route table should be unchanged after rollback"
+    );
+
+    let post_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table");
+
+    assert_eq!(
+        post_nat_table.entries.len(),
+        initial_nat_table.entries.len(),
+        "NAT table should be unchanged after rollback"
+    );
+
+    let post_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table");
+
+    assert_eq!(
+        post_bitmap_table.entries.len(),
+        initial_bitmap_table.entries.len(),
+        "Bitmap table should be unchanged after rollback"
+    );
+
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_member_update_failure() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 103));
+
+    // Create internal group with initial members
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("rollback_member_test"),
+        &[
+            (PhysPort(15), types::Direction::External),
+            (PhysPort(17), types::Direction::Underlay),
+        ],
+        None,
+        false,
+        None,
+    )
+    .await;
+
+    // Get initial state
+    let initial_group = switch
+        .client
+        .multicast_group_get(&internal_group_ip)
+        .await
+        .expect("Should be able to get initial group state");
+    let initial_member_count = initial_group.members.len();
+
+    // Try to add a member that should cause ASIC operations to fail
+    // Use a valid port but with an invalid link ID that should cause issues
+    let (valid_port_id, _) = switch.link_id(PhysPort(15)).unwrap(); // Use valid port 15
+    let invalid_members = vec![types::MulticastGroupMember {
+        port_id: valid_port_id,
+        link_id: types::LinkId(255), // Use max u8 value which should cause ASIC failure
+        direction: types::Direction::External,
+    }];
+
+    let update_request = types::MulticastGroupUpdateEntry {
+        members: invalid_members,
+        tag: None,
+    };
+
+    // This should fail and trigger rollback
+    let result = switch
+        .client
+        .multicast_group_update(&internal_group_ip, &update_request)
+        .await;
+
+    // Verify the update failed
+    assert!(result.is_err(), "Member update should have failed");
+
+    // Verify rollback worked - group should be unchanged
+    let post_failure_group = switch
+        .client
+        .multicast_group_get(&internal_group_ip)
+        .await
+        .expect("Should be able to get group state after rollback");
+
+    assert_eq!(
+        post_failure_group.members.len(),
+        initial_member_count,
+        "Member count should be unchanged after rollback"
+    );
+
+    // Verify the specific members are unchanged
+    assert_eq!(
+        post_failure_group.members, initial_group.members,
+        "Members should be unchanged after rollback"
+    );
+
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_nat_transition_failure() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 104));
+    let external_group_ip = IpAddr::V4(Ipv4Addr::new(224, 1, 2, 104));
+
+    // Create internal group
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("nat_rollback_test"),
+        &[(PhysPort(15), types::Direction::External)],
+        None,
+        false,
+        None,
+    )
+    .await;
+
+    // Create external group with NAT
+    let nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x02, 0x68).into(),
+        vni: 104.into(),
+    };
+
+    let external_entry = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        sources: None,
+        vlan_id: Some(10),
+        nat_target: nat_target.clone(),
+        tag: None,
+    };
+
+    switch
+        .client
+        .multicast_group_create_external(&external_entry)
+        .await
+        .expect("Should create external group for NAT rollback test");
+
+    // Get initial external group state
+    let initial_external_group = switch
+        .client
+        .multicast_group_get(&external_group_ip)
+        .await
+        .expect("Should be able to get initial external group state");
+
+    // Get initial NAT table state
+    let initial_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table");
+
+    // Attempt to update NAT target to invalid configuration that should fail
+    let invalid_nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF).into(), // Invalid MAC
+        vni: u32::MAX.into(), // Invalid VNI
+    };
+
+    let invalid_update = types::MulticastGroupUpdateExternalEntry {
+        sources: None,
+        nat_target: invalid_nat_target,
+        vlan_id: Some(10),
+        tag: None,
+    };
+
+    // This should fail and trigger NAT rollback
+    let result = switch
+        .client
+        .multicast_group_update_external(&external_group_ip, &invalid_update)
+        .await;
+
+    // Verify the update failed
+    assert!(result.is_err(), "NAT update should have failed");
+
+    // Verify rollback worked - external group should be unchanged
+    let post_failure_external_group = switch
+        .client
+        .multicast_group_get(&external_group_ip)
+        .await
+        .expect("Should be able to get external group state after rollback");
+
+    // NAT target should be unchanged
+    if let Some(ref original_nat) =
+        initial_external_group.int_fwding.nat_target.as_ref()
+    {
+        if let Some(ref current_nat) =
+            post_failure_external_group.int_fwding.nat_target
+        {
+            assert_eq!(
+                current_nat.vni, original_nat.vni,
+                "VNI should be unchanged after rollback"
+            );
+            assert_eq!(
+                current_nat.inner_mac, original_nat.inner_mac,
+                "MAC should be unchanged after rollback"
+            );
+        }
+    }
+
+    // Verify NAT table state is unchanged
+    let post_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table");
+
+    assert_eq!(
+        post_nat_table.entries.len(),
+        initial_nat_table.entries.len(),
+        "NAT table should be unchanged after rollback"
+    );
+
+    cleanup_test_group(&switch, external_group_ip)
+        .await
+        .unwrap();
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_vlan_propagation_consistency() {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 105));
+    let external_group_ip = IpAddr::V4(Ipv4Addr::new(224, 1, 2, 105));
+
+    // Create internal group with members (so bitmap entry get created)
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("vlan_propagation_test"),
+        &[
+            (PhysPort(15), types::Direction::External),
+            (PhysPort(17), types::Direction::Underlay),
+        ],
+        None,
+        false,
+        None,
+    )
+    .await;
+
+    // Get initial bitmap table state
+    let _initial_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table");
+
+    // First, delete the internal group to break the NAT target reference
+    cleanup_test_group(&switch, internal_group_ip)
+        .await
+        .expect("Should cleanup internal group");
+
+    let nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x02, 0x69).into(),
+        vni: 105.into(),
+    };
+
+    // Get initial table states before attempting creation
+    let initial_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table");
+    let initial_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table");
+
+    // Attempt to create external group that references the deleted internal group
+    let external_entry = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        sources: None,
+        vlan_id: Some(999),
+        nat_target,
+        tag: None,
+    };
+
+    // This should fail because the NAT target (internal group) no longer exists
+    let result = switch
+        .client
+        .multicast_group_create_external(&external_entry)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "External group creation should fail when NAT target doesn't exist"
+    );
+
+    // Verify rollback worked - tables should remain unchanged
+    let post_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table after rollback");
+    let post_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table after rollback");
+
+    assert_eq!(
+        initial_route_table.entries.len(),
+        post_route_table.entries.len(),
+        "Route table should be unchanged after rollback"
+    );
+    assert_eq!(
+        initial_bitmap_table.entries.len(),
+        post_bitmap_table.entries.len(),
+        "Bitmap table should be unchanged after rollback"
+    );
+
+    // No external group should exist since creation failed
+    let groups = switch
+        .client
+        .multicast_groups_list(None, None)
+        .await
+        .expect("Should be able to list groups after rollback");
+
+    let external_groups: Vec<_> = groups
+        .items
+        .iter()
+        .filter(|g| g.group_ip == external_group_ip)
+        .collect();
+
+    assert!(
+        external_groups.is_empty(),
+        "No external group should exist after failed creation"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_source_filter_update() -> TestResult {
+    let switch = &*get_switch().await;
+
+    // First create the internal admin-scoped group that will be the NAT target
+    let internal_multicast_ip = IpAddr::V6(MULTICAST_NAT_IP);
+    let egress1 = PhysPort(28);
+    create_test_multicast_group(
+        switch,
+        internal_multicast_ip,
+        Some("rollback_internal"),
+        &[(egress1, types::Direction::External)],
+        None,
+        false, // No NAT needed for internal groups
+        None,
+    )
+    .await;
+
+    // Create IPv4 SSM group that supports source filters
+    let group_ip = IpAddr::V4(Ipv4Addr::new(232, 1, 1, 100)); // SSM range
+    let nat_target = types::NatTarget {
+        internal_ip: MULTICAST_NAT_IP.into(),
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x01, 0x64).into(),
+        vni: 100.into(),
+    };
+
+    // Create initial SSM group with source filters
+    let initial_sources = vec![
+        types::IpSrc::Exact("10.1.1.1".parse().unwrap()),
+        types::IpSrc::Exact("10.1.1.2".parse().unwrap()),
+    ];
+
+    let external_group = types::MulticastGroupCreateExternalEntry {
+        group_ip,
+        sources: Some(initial_sources.clone()),
+        vlan_id: Some(10),
+        nat_target,
+        tag: Some("source_filter_rollback_test".to_string()),
+    };
+
+    switch
+        .client
+        .multicast_group_create_external(&external_group)
+        .await
+        .expect("Should create SSM group with initial source filters");
+
+    // Get initial source filter table state
+    let initial_src_table = switch
+        .client
+        .table_dump("pipe.Ingress.mcast_ingress.mcast_source_filter_ipv4")
+        .await
+        .expect("Should be able to dump source filter table");
+
+    // Try to update with invalid sources that should cause validation failure and rollback
+    let invalid_sources = vec![
+        types::IpSrc::Exact("10.2.2.1".parse().unwrap()), // Valid source
+        types::IpSrc::Exact("224.1.1.1".parse().unwrap()), // Invalid: multicast IP as source - should cause rollback
+    ];
+
+    let failing_update_entry = types::MulticastGroupUpdateExternalEntry {
+        sources: Some(invalid_sources),
+        nat_target: external_group.nat_target.clone(),
+        vlan_id: Some(10),
+        tag: None,
+    };
+
+    // This update should fail due to invalid multicast source IP
+    let result = switch
+        .client
+        .multicast_group_update_external(&group_ip, &failing_update_entry)
+        .await;
+
+    // Verify the update failed
+    assert!(
+        result.is_err(),
+        "Update should have failed with invalid multicast source IP"
+    );
+
+    // Verify rollback worked - original sources should still be in place
+    let post_rollback_group = switch
+        .client
+        .multicast_group_get(&group_ip)
+        .await
+        .expect("Should be able to get group after rollback");
+
+    assert_eq!(
+        post_rollback_group.sources.as_ref().unwrap().len(),
+        initial_sources.len(),
+        "Source count should be unchanged after rollback"
+    );
+
+    // Verify source filter table is back to initial state (rollback worked)
+    let post_rollback_src_table = switch
+        .client
+        .table_dump("pipe.Ingress.mcast_ingress.mcast_source_filter_ipv4")
+        .await
+        .expect("Should be able to dump source filter table after rollback");
+
+    assert_eq!(
+        post_rollback_src_table.entries.len(),
+        initial_src_table.entries.len(),
+        "Source filter table should be unchanged after rollback"
+    );
+
+    // Clean up internal group
+    cleanup_test_group(&switch, internal_multicast_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_partial_member_addition() -> TestResult {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 106));
+
+    // Create internal group with initial members
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("partial_add_rollback_test"),
+        &[
+            (PhysPort(15), types::Direction::External),
+            (PhysPort(16), types::Direction::Underlay),
+        ],
+        None,
+        false,
+        None,
+    )
+    .await;
+
+    let initial_group = switch
+        .client
+        .multicast_group_get(&internal_group_ip)
+        .await
+        .expect("Should be able to get initial group state");
+    let initial_member_count = initial_group.members.len();
+
+    // Create a mix of valid and invalid members to trigger partial addition failure
+    let (valid_port_1, valid_link_1) = switch.link_id(PhysPort(17)).unwrap();
+    let (valid_port_2, valid_link_2) = switch.link_id(PhysPort(18)).unwrap();
+    let (valid_port_3, _) = switch.link_id(PhysPort(19)).unwrap();
+
+    let mixed_members = vec![
+        // Valid member - should be added successfully
+        types::MulticastGroupMember {
+            port_id: valid_port_1,
+            link_id: valid_link_1,
+            direction: types::Direction::External,
+        },
+        // Valid member - should be added successfully
+        types::MulticastGroupMember {
+            port_id: valid_port_2,
+            link_id: valid_link_2,
+            direction: types::Direction::Underlay,
+        },
+        // Invalid member - should cause failure after partial success
+        types::MulticastGroupMember {
+            port_id: valid_port_3,
+            link_id: types::LinkId(250), // Invalid link ID
+            direction: types::Direction::External,
+        },
+    ];
+
+    let update_request = types::MulticastGroupUpdateEntry {
+        members: mixed_members,
+        tag: None,
+    };
+
+    // This should fail after partially adding some members, triggering incremental rollback
+    let result = switch
+        .client
+        .multicast_group_update(&internal_group_ip, &update_request)
+        .await;
+
+    // Verify the update failed
+    assert!(
+        result.is_err(),
+        "Partial member addition should have failed with invalid link ID"
+    );
+
+    // Verify rollback worked - should be back to original state
+    let post_failure_group = switch
+        .client
+        .multicast_group_get(&internal_group_ip)
+        .await
+        .expect("Should be able to get group state after rollback");
+
+    assert_eq!(
+        post_failure_group.members.len(),
+        initial_member_count,
+        "Member count should be unchanged after partial addition rollback"
+    );
+
+    // Verify the original members are still present and unchanged
+    assert_eq!(
+        post_failure_group.members, initial_group.members,
+        "Members should be unchanged after partial addition rollback"
+    );
+
+    cleanup_test_group(&switch, internal_group_ip).await
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multicast_rollback_table_operation_failure() {
+    let switch = &*get_switch().await;
+
+    let internal_group_ip =
+        IpAddr::V6(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 107));
+    let external_group_ip = IpAddr::V4(Ipv4Addr::new(224, 1, 2, 107));
+
+    // Create internal group first
+    create_test_multicast_group(
+        &switch,
+        internal_group_ip,
+        Some("table_rollback_test"),
+        &[
+            (PhysPort(15), types::Direction::External),
+            (PhysPort(17), types::Direction::Underlay),
+        ],
+        None,
+        false,
+        None,
+    )
+    .await;
+
+    // Delete the internal group to break the NAT target reference
+    cleanup_test_group(&switch, internal_group_ip)
+        .await
+        .expect("Should cleanup internal group");
+
+    // Get table states after internal group deletion but before external group attempt
+    let initial_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table");
+    let initial_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table");
+    let initial_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table");
+
+    // Attempt to create external group that references the non-existent internal group
+    let broken_nat_target = types::NatTarget {
+        internal_ip: match internal_group_ip {
+            IpAddr::V6(ipv6) => ipv6,
+            _ => panic!("Expected IPv6 address"),
+        },
+        inner_mac: MacAddr::new(0x01, 0x00, 0x5e, 0x01, 0x02, 0x6b).into(),
+        vni: 107.into(),
+    };
+
+    let external_entry = types::MulticastGroupCreateExternalEntry {
+        group_ip: external_group_ip,
+        sources: None,
+        vlan_id: Some(200),
+        nat_target: broken_nat_target,
+        tag: None,
+    };
+
+    // This should fail because the NAT target (internal group) doesn't exist
+    let result = switch
+        .client
+        .multicast_group_create_external(&external_entry)
+        .await;
+
+    // Verify the creation failed
+    assert!(
+        result.is_err(),
+        "External group creation should fail when NAT target doesn't exist"
+    );
+
+    // Verify table rollback worked - all tables should be unchanged
+    let post_route_table = switch
+        .client
+        .table_dump("pipe.Ingress.l3_router.MulticastRouter4.tbl")
+        .await
+        .expect("Should be able to dump route table after rollback");
+
+    let post_nat_table = switch
+        .client
+        .table_dump("pipe.Ingress.nat_ingress.ingress_ipv4_mcast")
+        .await
+        .expect("Should be able to dump NAT table after rollback");
+
+    let post_bitmap_table = switch
+        .client
+        .table_dump("pipe.Egress.mcast_egress.tbl_decap_ports")
+        .await
+        .expect("Should be able to dump bitmap table after rollback");
+
+    assert_eq!(
+        post_route_table.entries.len(),
+        initial_route_table.entries.len(),
+        "Route table should be unchanged after table operation rollback"
+    );
+
+    assert_eq!(
+        post_nat_table.entries.len(),
+        initial_nat_table.entries.len(),
+        "NAT table should be unchanged after table operation rollback"
+    );
+
+    assert_eq!(
+        post_bitmap_table.entries.len(),
+        initial_bitmap_table.entries.len(),
+        "Bitmap table should be unchanged after table operation rollback"
+    );
+
+    // Verify no external group was created
+    let groups = switch
+        .client
+        .multicast_groups_list(None, None)
+        .await
+        .expect("Should be able to list groups after rollback");
+
+    let external_groups: Vec<_> = groups
+        .items
+        .iter()
+        .filter(|g| g.group_ip == external_group_ip)
+        .collect();
+
+    assert!(
+        external_groups.is_empty(),
+        "No external group should exist after table operation rollback"
+    );
 }

--- a/dpd-client/tests/integration_tests/table_tests.rs
+++ b/dpd-client/tests/integration_tests/table_tests.rs
@@ -459,13 +459,13 @@ async fn test_routev6_full() -> TestResult {
 
 struct MulticastReplicationTableTest {}
 
-impl TableTest<types::MulticastGroupResponse, ()>
+impl TableTest<types::MulticastGroupUnderlayResponse, ()>
     for MulticastReplicationTableTest
 {
     async fn insert_entry(
         switch: &Switch,
         idx: usize,
-    ) -> OpResult<types::MulticastGroupResponse> {
+    ) -> OpResult<types::MulticastGroupUnderlayResponse> {
         let (port_id1, link_id1) = switch.link_id(PhysPort(11)).unwrap();
         let (port_id2, link_id2) = switch.link_id(PhysPort(12)).unwrap();
 
@@ -473,8 +473,8 @@ impl TableTest<types::MulticastGroupResponse, ()>
         let group_ip = gen_ipv6_multicast_addr(idx);
 
         // Admin-scoped IPv6 groups are internal with replication info and members
-        let internal_entry = types::MulticastGroupCreateEntry {
-            group_ip,
+        let internal_entry = types::MulticastGroupCreateUnderlayEntry {
+            group_ip: types::AdminScopedIpv6(group_ip),
             tag: Some(MCAST_TAG.to_string()),
             members: vec![
                 types::MulticastGroupMember {
@@ -489,7 +489,10 @@ impl TableTest<types::MulticastGroupResponse, ()>
                 },
             ],
         };
-        switch.client.multicast_group_create(&internal_entry).await
+        switch
+            .client
+            .multicast_group_create_underlay(&internal_entry)
+            .await
     }
 
     async fn delete_entry(switch: &Switch, idx: usize) -> OpResult<()> {
@@ -498,7 +501,7 @@ impl TableTest<types::MulticastGroupResponse, ()>
     }
 
     async fn count_entries(switch: &Switch) -> usize {
-        // Count all groups with our test tag
+        // Count only underlay groups with our test tag (since this tests replication table capacity)
         switch
             .client
             .multicast_groups_list_by_tag_stream(MCAST_TAG, None)
@@ -514,7 +517,7 @@ impl TableTest<types::MulticastGroupResponse, ()>
 async fn test_multicast_replication_table_full() -> TestResult {
     test_table_capacity::<
         MulticastReplicationTableTest,
-        types::MulticastGroupResponse,
+        types::MulticastGroupUnderlayResponse,
         (),
     >(MULTICAST_TABLE_SIZE)
     .await

--- a/dpd-client/tests/integration_tests/table_tests.rs
+++ b/dpd-client/tests/integration_tests/table_tests.rs
@@ -476,7 +476,6 @@ impl TableTest<types::MulticastGroupResponse, ()>
         let internal_entry = types::MulticastGroupCreateEntry {
             group_ip,
             tag: Some(MCAST_TAG.to_string()),
-            sources: None,
             members: vec![
                 types::MulticastGroupMember {
                     port_id: port_id1.clone(),

--- a/dpd-types/src/mcast.rs
+++ b/dpd-types/src/mcast.rs
@@ -19,17 +19,6 @@ use crate::link::LinkId;
 /// Type alias for multicast group IDs.
 pub type MulticastGroupId = u16;
 
-/// A multicast group configuration for POST requests for external (to the rack)
-/// groups.
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct MulticastGroupCreateExternalEntry {
-    pub group_ip: IpAddr,
-    pub tag: Option<String>,
-    pub nat_target: NatTarget,
-    pub vlan_id: Option<u16>,
-    pub sources: Option<Vec<IpSrc>>,
-}
-
 /// Source filter match key for multicast traffic.
 #[derive(
     Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema,
@@ -58,6 +47,17 @@ pub struct MulticastGroupCreateEntry {
     pub tag: Option<String>,
     pub sources: Option<Vec<IpSrc>>,
     pub members: Vec<MulticastGroupMember>,
+}
+
+/// A multicast group configuration for POST requests for external (to the rack)
+/// groups.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct MulticastGroupCreateExternalEntry {
+    pub group_ip: IpAddr,
+    pub tag: Option<String>,
+    pub nat_target: NatTarget,
+    pub vlan_id: Option<u16>,
+    pub sources: Option<Vec<IpSrc>>,
 }
 
 /// Represents a multicast replication entry for PUT requests for internal

--- a/dpd-types/src/mcast.rs
+++ b/dpd-types/src/mcast.rs
@@ -4,13 +4,15 @@
 //
 // Copyright 2025 Oxide Computer Company
 
+//! Public types for multicast group management.
+
 use std::{
     fmt,
     net::{IpAddr, Ipv6Addr},
 };
 
 use common::{nat::NatTarget, ports::PortId};
-use oxnet::Ipv4Net;
+use oxnet::{Ipv4Net, Ipv6Net};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +20,62 @@ use crate::link::LinkId;
 
 /// Type alias for multicast group IDs.
 pub type MulticastGroupId = u16;
+
+/// A validated admin-scoped IPv6 multicast address.
+///
+/// Admin-scoped addresses are ff04::/16, ff05::/16, or ff08::/16.
+/// These are used for internal/underlay multicast groups.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+#[serde(try_from = "Ipv6Addr", into = "Ipv6Addr")]
+pub struct AdminScopedIpv6(Ipv6Addr);
+
+impl AdminScopedIpv6 {
+    /// Create a new AdminScopedIpv6 if the address is admin-scoped.
+    pub fn new(addr: Ipv6Addr) -> Result<Self, Error> {
+        if !Ipv6Net::new_unchecked(addr, 128).is_admin_scoped_multicast() {
+            return Err(Error::InvalidIp(addr));
+        }
+        Ok(Self(addr))
+    }
+}
+
+impl TryFrom<Ipv6Addr> for AdminScopedIpv6 {
+    type Error = Error;
+
+    fn try_from(addr: Ipv6Addr) -> Result<Self, Self::Error> {
+        Self::new(addr)
+    }
+}
+
+impl From<AdminScopedIpv6> for Ipv6Addr {
+    fn from(admin: AdminScopedIpv6) -> Self {
+        admin.0
+    }
+}
+
+impl From<AdminScopedIpv6> for IpAddr {
+    fn from(admin: AdminScopedIpv6) -> Self {
+        IpAddr::V6(admin.0)
+    }
+}
+
+impl fmt::Display for AdminScopedIpv6 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 /// Source filter match key for multicast traffic.
 #[derive(
@@ -42,10 +100,9 @@ impl fmt::Display for IpSrc {
 /// A multicast group configuration for POST requests for internal (to the rack)
 /// groups.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct MulticastGroupCreateEntry {
-    pub group_ip: Ipv6Addr,
+pub struct MulticastGroupCreateUnderlayEntry {
+    pub group_ip: AdminScopedIpv6,
     pub tag: Option<String>,
-    pub sources: Option<Vec<IpSrc>>,
     pub members: Vec<MulticastGroupMember>,
 }
 
@@ -55,17 +112,16 @@ pub struct MulticastGroupCreateEntry {
 pub struct MulticastGroupCreateExternalEntry {
     pub group_ip: IpAddr,
     pub tag: Option<String>,
-    pub nat_target: NatTarget,
-    pub vlan_id: Option<u16>,
+    pub internal_forwarding: InternalForwarding,
+    pub external_forwarding: ExternalForwarding,
     pub sources: Option<Vec<IpSrc>>,
 }
 
 /// Represents a multicast replication entry for PUT requests for internal
 /// (to the rack) groups.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct MulticastGroupUpdateEntry {
+pub struct MulticastGroupUpdateUnderlayEntry {
     pub tag: Option<String>,
-    pub sources: Option<Vec<IpSrc>>,
     pub members: Vec<MulticastGroupMember>,
 }
 
@@ -74,22 +130,52 @@ pub struct MulticastGroupUpdateEntry {
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct MulticastGroupUpdateExternalEntry {
     pub tag: Option<String>,
-    pub nat_target: NatTarget,
-    pub vlan_id: Option<u16>,
+    pub internal_forwarding: InternalForwarding,
+    pub external_forwarding: ExternalForwarding,
     pub sources: Option<Vec<IpSrc>>,
 }
 
-/// Response structure for multicast group operations.
+/// Response structure for underlay/internal multicast group operations.
+/// These groups handle admin-scoped IPv6 multicast with full replication.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct MulticastGroupResponse {
-    pub group_ip: IpAddr,
-    pub external_group_id: Option<MulticastGroupId>,
-    pub underlay_group_id: Option<MulticastGroupId>,
+pub struct MulticastGroupUnderlayResponse {
+    pub group_ip: AdminScopedIpv6,
+    pub external_group_id: MulticastGroupId,
+    pub underlay_group_id: MulticastGroupId,
     pub tag: Option<String>,
-    pub int_fwding: InternalForwarding,
-    pub ext_fwding: ExternalForwarding,
-    pub sources: Option<Vec<IpSrc>>,
     pub members: Vec<MulticastGroupMember>,
+}
+
+/// Response structure for external multicast group operations.
+/// These groups handle IPv4 and non-admin IPv6 multicast via NAT targets.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct MulticastGroupExternalResponse {
+    pub group_ip: IpAddr,
+    pub external_group_id: MulticastGroupId,
+    pub tag: Option<String>,
+    pub internal_forwarding: InternalForwarding,
+    pub external_forwarding: ExternalForwarding,
+    pub sources: Option<Vec<IpSrc>>,
+}
+
+/// Unified response type for operations that return mixed group types.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(tag = "kind")]
+pub enum MulticastGroupResponse {
+    #[serde(rename = "underlay")]
+    Underlay(MulticastGroupUnderlayResponse),
+    #[serde(rename = "external")]
+    External(MulticastGroupExternalResponse),
+}
+
+impl MulticastGroupResponse {
+    /// Get the multicast group IP address.
+    pub fn ip(&self) -> IpAddr {
+        match self {
+            Self::Underlay(resp) => resp.group_ip.into(),
+            Self::External(resp) => resp.group_ip,
+        }
+    }
 }
 
 /// Represents the NAT target for multicast traffic for internal/underlay
@@ -125,4 +211,12 @@ pub struct MulticastGroupMember {
 pub enum Direction {
     Underlay,
     External,
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Error {
+    #[error(
+        "Address {0} is not admin-scoped (must be ff04::/16, ff05::/16, or ff08::/16)"
+    )]
+    InvalidIp(Ipv6Addr),
 }

--- a/dpd-types/src/mcast.rs
+++ b/dpd-types/src/mcast.rs
@@ -160,11 +160,9 @@ pub struct MulticastGroupExternalResponse {
 
 /// Unified response type for operations that return mixed group types.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[serde(tag = "kind")]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MulticastGroupResponse {
-    #[serde(rename = "underlay")]
     Underlay(MulticastGroupUnderlayResponse),
-    #[serde(rename = "external")]
     External(MulticastGroupExternalResponse),
 }
 

--- a/dpd/src/api_server.rs
+++ b/dpd/src/api_server.rs
@@ -1931,9 +1931,6 @@ impl DpdApi for DpdApiImpl {
     {
         let switch: &Switch = rqctx.context();
 
-        // If a group ID is provided, get the group by ID
-
-        // If no group ID is provided, paginate through the groups
         let pag_params = query_params.into_inner();
         let Ok(limit) = usize::try_from(rqctx.page_limit(&pag_params)?.get())
         else {

--- a/dpd/src/mcast/mod.rs
+++ b/dpd/src/mcast/mod.rs
@@ -329,8 +329,8 @@ pub(crate) fn add_group_external(
     let internal_group =
         mcast.groups.get(&internal_group_ip).ok_or_else(|| {
             DpdError::Invalid(format!(
-                r#"multicast group for IP address {group_ip} must have a NAT target
-                   that is also a tracked multicast group"#,
+                "multicast group for IP address {group_ip} must have a NAT target \
+                 that is also a tracked multicast group",
             ))
         })?;
 
@@ -947,14 +947,16 @@ fn perform_vlan_propagation(
 ) -> DpdResult<()> {
     debug!(
         s.log,
-        r#"external group with VLAN references internal group, propagating VLAN:
-           external_group={group_ip}, vlan={vlan_id}, internal_group={internal_ip}"#
+        "external group with VLAN references internal group, propagating VLAN";
+        "external_group" => %group_ip,
+        "vlan" => vlan_id,
+        "internal_group" => %internal_ip,
     );
 
     let internal_group = mcast.groups.get(&internal_ip).ok_or_else(|| {
         DpdError::McastGroupFailure(format!(
-            r#"internal group not found during VLAN propagation:
-               internal_group={internal_ip}, external_group={group_ip}"#
+            "internal group not found during VLAN propagation: \
+             internal_group={internal_ip}, external_group={group_ip}"
         ))
     })?;
 
@@ -1194,8 +1196,10 @@ fn delete_multicast_groups(
     if let Err(e) = s.asic_hdl.mc_group_destroy(external_id) {
         warn!(
             s.log,
-            r#"failed to delete external multicast group:
-               IP={group_ip}, ID={external_id}, error={e:?}"#
+            "failed to delete external multicast group";
+            "IP" => %group_ip,
+            "ID" => external_id,
+            "error" => ?e,
         );
     }
 
@@ -1203,8 +1207,10 @@ fn delete_multicast_groups(
     if let Err(e) = s.asic_hdl.mc_group_destroy(underlay_id) {
         warn!(
             s.log,
-            r#"failed to delete underlay multicast group:
-               IP={group_ip}, ID={underlay_id}, error={e:?}"#
+            "failed to delete underlay multicast group";
+            "IP" => %group_ip,
+            "ID" => underlay_id,
+            "error" => ?e,
         );
     }
 
@@ -1220,8 +1226,8 @@ fn create_asic_group(
         .mc_group_create(group_id)
         .map_err(|e: AsicError| {
             DpdError::McastGroupFailure(format!(
-                r#"failed to create multicast group for IP {group_ip} with ID
-                   {group_id}: {e:?}"#
+                "failed to create multicast group for IP {group_ip} with ID \
+                 {group_id}: {e:?}"
             ))
         })
 }

--- a/dpd/src/mcast/rollback.rs
+++ b/dpd/src/mcast/rollback.rs
@@ -1,0 +1,669 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/
+//
+// Copyright 2025 Oxide Computer Company
+
+//! Rollback contexts for multicast group operations.
+//!
+//! This module provides consistent rollback handling for multicast group
+//! creation and update operations. It includes context helpers that capture
+//! rollback parameters once and provide reusable error handling throughout
+//! multi-step operations.
+
+use std::{fmt, net::IpAddr};
+
+use aal::AsicOps;
+use oxnet::Ipv4Net;
+use slog::{debug, error};
+
+use common::{nat::NatTarget, ports::PortId};
+
+use super::{
+    add_source_filters, remove_source_filters, update_fwding_tables,
+    update_replication_tables, Direction, IpSrc, LinkId, MulticastGroup,
+    MulticastGroupId, MulticastGroupMember, MulticastReplicationInfo,
+};
+use crate::{table, types::DpdResult, Switch};
+
+/// Trait providing shared rollback functionality for multicast group operations.
+///
+/// This trait encapsulates common rollback operations that are needed by both
+/// group creation and update contexts.
+trait RollbackOps {
+    fn switch(&self) -> &Switch;
+    fn group_ip(&self) -> IpAddr;
+    fn external_group_id(&self) -> MulticastGroupId;
+    fn underlay_group_id(&self) -> MulticastGroupId;
+
+    /// Rollback port changes (removing added ports, re-adding removed ports).
+    /// Each group type implements this differently - external groups are no-op, internal groups handle ports.
+    fn rollback_ports(
+        &self,
+        added_ports: &[MulticastGroupMember],
+        removed_ports: &[MulticastGroupMember],
+        replication_info: &MulticastReplicationInfo,
+    ) -> DpdResult<()>;
+
+    /// Rollback source filter changes.
+    fn rollback_source_filters(
+        &self,
+        new_sources: Option<&[IpSrc]>,
+        orig_sources: Option<&[IpSrc]>,
+    ) -> DpdResult<()> {
+        self.log_rollback_error(
+            "remove new source filters",
+            &format!("for group {}", self.group_ip()),
+            remove_source_filters(self.switch(), self.group_ip(), new_sources),
+        );
+        self.log_rollback_error(
+            "restore original source filters",
+            &format!("for group {}", self.group_ip()),
+            add_source_filters(self.switch(), self.group_ip(), orig_sources),
+        );
+        Ok(())
+    }
+
+    /// Rollback internal group changes (ports only, no sources).
+    fn rollback_internal_update(
+        &self,
+        added_ports: &[MulticastGroupMember],
+        removed_ports: &[MulticastGroupMember],
+        replication_info: &MulticastReplicationInfo,
+    ) -> DpdResult<()> {
+        self.collect_rollback_result("port changes", || {
+            self.rollback_ports(added_ports, removed_ports, replication_info)
+        });
+
+        Ok(())
+    }
+
+    /// Execute rollback operation and track errors for summary logging.
+    fn collect_rollback_result<F>(&self, operation: &str, f: F) -> bool
+    where
+        F: FnOnce() -> DpdResult<()>,
+    {
+        match f() {
+            Ok(()) => false,
+            Err(e) => {
+                debug!(
+                    self.switch().log,
+                    "failed {} during rollback: {:?}", operation, e
+                );
+                true
+            }
+        }
+    }
+
+    /// Log rollback errors without propagating them.
+    fn log_rollback_error<T, E: fmt::Debug>(
+        &self,
+        operation: &str,
+        context: &str,
+        result: Result<T, E>,
+    ) {
+        if let Err(e) = result {
+            debug!(
+                self.switch().log,
+                "failed to {} during rollback {}: {:?}", operation, context, e
+            );
+        }
+    }
+}
+
+/// Rollback context for multicast group creation operations.
+pub(crate) struct GroupCreateRollbackContext<'a> {
+    switch: &'a Switch,
+    group_ip: IpAddr,
+    external_id: MulticastGroupId,
+    underlay_id: MulticastGroupId,
+    nat_target: Option<NatTarget>,
+    sources: Option<&'a [IpSrc]>,
+}
+
+impl RollbackOps for GroupCreateRollbackContext<'_> {
+    fn switch(&self) -> &Switch {
+        self.switch
+    }
+
+    fn group_ip(&self) -> IpAddr {
+        self.group_ip
+    }
+
+    fn external_group_id(&self) -> MulticastGroupId {
+        self.external_id
+    }
+
+    fn underlay_group_id(&self) -> MulticastGroupId {
+        self.underlay_id
+    }
+
+    fn rollback_ports(
+        &self,
+        added_ports: &[MulticastGroupMember],
+        _removed_ports: &[MulticastGroupMember],
+        _replication_info: &MulticastReplicationInfo,
+    ) -> DpdResult<()> {
+        if self.nat_target.is_some() {
+            Ok(())
+        } else {
+            debug!(
+                self.switch.log,
+                "rolling back multicast group creation: group={}, ports={}",
+                self.group_ip,
+                added_ports.len()
+            );
+
+            for member in added_ports {
+                let group_id = match member.direction {
+                    Direction::External => self.external_id,
+                    Direction::Underlay => self.underlay_id,
+                };
+
+                match self
+                    .switch
+                    .port_link_to_asic_id(member.port_id, member.link_id)
+                {
+                    Ok(asic_id) => {
+                        if let Err(e) = self
+                            .switch
+                            .asic_hdl
+                            .mc_port_remove(group_id, asic_id)
+                        {
+                            error!(
+                                self.switch.log,
+                                "failed to remove port during rollback: port={}, asic_id={}, group={}, error={:?}",
+                                member.port_id,
+                                asic_id,
+                                group_id,
+                                e
+                            );
+                            return Err(e.into());
+                        }
+                    }
+                    Err(e) => {
+                        error!(
+                            self.switch.log,
+                            "failed to resolve port link during rollback: port={}, link={}, error={:?}",
+                            member.port_id,
+                            member.link_id,
+                            e
+                        );
+                        return Err(e);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+impl<'a> GroupCreateRollbackContext<'a> {
+    /// Create rollback context for external group operations.
+    pub(crate) fn new_external(
+        switch: &'a Switch,
+        group_ip: IpAddr,
+        external_id: MulticastGroupId,
+        underlay_id: MulticastGroupId,
+        nat_target: NatTarget,
+        sources: Option<&'a [IpSrc]>,
+    ) -> Self {
+        Self {
+            switch,
+            group_ip,
+            external_id,
+            underlay_id,
+            nat_target: Some(nat_target),
+            sources,
+        }
+    }
+
+    /// Create rollback context for internal group operations.
+    pub(crate) fn new_internal(
+        switch: &'a Switch,
+        group_ip: IpAddr,
+        external_id: MulticastGroupId,
+        underlay_id: MulticastGroupId,
+    ) -> Self {
+        Self {
+            switch,
+            group_ip,
+            external_id,
+            underlay_id,
+            nat_target: None,
+            sources: None,
+        }
+    }
+
+    /// Perform rollback with member context and return error.
+    pub(crate) fn rollback_with_members_and_return_error<E>(
+        &self,
+        error: E,
+        added_members: &[(PortId, LinkId, Direction)],
+        replication_info: &MulticastReplicationInfo,
+    ) -> E {
+        if let Err(rollback_err) =
+            self.perform_group_create_rollback(added_members, replication_info)
+        {
+            error!(
+                self.switch.log,
+                "rollback failed for group creation: group={}, error={:?}",
+                self.group_ip,
+                rollback_err
+            );
+        }
+        error
+    }
+
+    /// Perform rollback and return error.
+    pub(crate) fn rollback_and_return_error<E>(&self, error: E) -> E {
+        self.rollback_with_members_and_return_error(
+            error,
+            &[],                                  // No members
+            &MulticastReplicationInfo::default(), // Dummy replication info
+        )
+    }
+
+    /// Perform group creation rollback.
+    fn perform_group_create_rollback(
+        &self,
+        added_members: &[(PortId, LinkId, Direction)],
+        replication_info: &MulticastReplicationInfo,
+    ) -> DpdResult<()> {
+        let added_members_converted: Vec<MulticastGroupMember> = added_members
+            .iter()
+            .map(|(port_id, link_id, direction)| MulticastGroupMember {
+                port_id: *port_id,
+                link_id: *link_id,
+                direction: *direction,
+            })
+            .collect();
+
+        self.collect_rollback_result("port removal", || {
+            self.rollback_ports(&added_members_converted, &[], replication_info)
+        });
+        self.collect_rollback_result("ASIC group deletion", || {
+            self.remove_groups()
+        });
+        self.collect_rollback_result("table cleanup", || self.remove_tables());
+
+        Ok(())
+    }
+
+    /// Remove multicast groups from ASIC.
+    fn remove_groups(&self) -> DpdResult<()> {
+        // External groups don't destroy ASIC groups (they're shared with internal group)
+        if self.nat_target.is_none() {
+            self.log_rollback_error(
+                "remove external multicast group",
+                &format!(
+                    "for IP {} with ID {}",
+                    self.group_ip, self.external_id
+                ),
+                self.switch.asic_hdl.mc_group_destroy(self.external_id),
+            );
+            self.log_rollback_error(
+                "remove underlay multicast group",
+                &format!(
+                    "for IP {} with ID {}",
+                    self.group_ip, self.underlay_id
+                ),
+                self.switch.asic_hdl.mc_group_destroy(self.underlay_id),
+            );
+        }
+        Ok(())
+    }
+
+    /// Remove table entries.
+    fn remove_tables(&self) -> DpdResult<()> {
+        match self.group_ip {
+            IpAddr::V4(ipv4) => {
+                // IPv4 groups are always external-only and never create bitmap entries
+                // (only IPv6 internal groups with replication create bitmap entries)
+
+                if let Some(srcs) = self.sources {
+                    for src in srcs {
+                        match src {
+                            IpSrc::Exact(IpAddr::V4(src)) => {
+                                let _ =
+                                    table::mcast::mcast_src_filter::del_ipv4_entry(
+                                        self.switch,
+                                        Ipv4Net::new(*src, 32).unwrap(),
+                                        ipv4,
+                                    );
+                            }
+                            IpSrc::Subnet(subnet) => {
+                                let _ =
+                                    table::mcast::mcast_src_filter::del_ipv4_entry(
+                                        self.switch, *subnet, ipv4,
+                                    );
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                if self.nat_target.is_some() {
+                    let _ = table::mcast::mcast_nat::del_ipv4_entry(
+                        self.switch,
+                        ipv4,
+                    );
+                }
+                let _ = table::mcast::mcast_route::del_ipv4_entry(
+                    self.switch,
+                    ipv4,
+                );
+            }
+            IpAddr::V6(ipv6) => {
+                // Clean up external bitmap entry only if both external and underlay groups exist
+                // (bitmap entries are only created for internal groups with both group types)
+                let _ = table::mcast::mcast_egress::del_bitmap_entry(
+                    self.switch,
+                    self.external_id,
+                );
+
+                let _ = table::mcast::mcast_replication::del_ipv6_entry(
+                    self.switch,
+                    ipv6,
+                );
+
+                if let Some(srcs) = self.sources {
+                    for src in srcs {
+                        if let IpSrc::Exact(IpAddr::V6(src)) = src {
+                            let _ =
+                                table::mcast::mcast_src_filter::del_ipv6_entry(
+                                    self.switch,
+                                    *src,
+                                    ipv6,
+                                );
+                        }
+                    }
+                }
+                if self.nat_target.is_some() {
+                    let _ = table::mcast::mcast_nat::del_ipv6_entry(
+                        self.switch,
+                        ipv6,
+                    );
+                }
+                let _ = table::mcast::mcast_route::del_ipv6_entry(
+                    self.switch,
+                    ipv6,
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Rollback context for multicast group update operations.
+pub(crate) struct GroupUpdateRollbackContext<'a> {
+    switch: &'a Switch,
+    group_ip: IpAddr,
+    original_group: &'a MulticastGroup,
+}
+
+impl RollbackOps for GroupUpdateRollbackContext<'_> {
+    fn switch(&self) -> &Switch {
+        self.switch
+    }
+
+    fn group_ip(&self) -> IpAddr {
+        self.group_ip
+    }
+
+    fn external_group_id(&self) -> MulticastGroupId {
+        self.original_group.external_group_id()
+    }
+
+    fn underlay_group_id(&self) -> MulticastGroupId {
+        self.original_group.underlay_group_id()
+    }
+
+    fn rollback_ports(
+        &self,
+        added_ports: &[MulticastGroupMember],
+        removed_ports: &[MulticastGroupMember],
+        replication_info: &MulticastReplicationInfo,
+    ) -> DpdResult<()> {
+        // External groups don't need port rollback
+        if self.original_group.replication_info.is_none() {
+            return Ok(());
+        }
+
+        // Internal group - perform actual port rollback
+        debug!(
+                self.switch.log,
+                "rolling back multicast group update: group={}, added_ports={}, removed_ports={}",
+                self.group_ip,
+                added_ports.len(),
+                removed_ports.len()
+            );
+
+        // Remove added ports
+        for member in added_ports {
+            let group_id = match member.direction {
+                Direction::External => self.external_group_id(),
+                Direction::Underlay => self.underlay_group_id(),
+            };
+
+            match self
+                .switch
+                .port_link_to_asic_id(member.port_id, member.link_id)
+            {
+                Ok(asic_id) => {
+                    if let Err(e) =
+                        self.switch.asic_hdl.mc_port_remove(group_id, asic_id)
+                    {
+                        error!(
+                                self.switch.log,
+                                "failed to remove port during rollback: port={}, asic_id={}, group={}, error={:?}",
+                                member.port_id,
+                                asic_id,
+                                group_id,
+                                e
+                            );
+                        return Err(e.into());
+                    }
+                }
+                Err(e) => {
+                    error!(
+                            self.switch.log,
+                            "failed to resolve port link during rollback: port={}, link={}, error={:?}",
+                            member.port_id,
+                            member.link_id,
+                            e
+                        );
+                    return Err(e);
+                }
+            }
+        }
+
+        // Re-add removed ports
+        for member in removed_ports {
+            let group_id = match member.direction {
+                Direction::External => self.external_group_id(),
+                Direction::Underlay => self.underlay_group_id(),
+            };
+
+            match self
+                .switch
+                .port_link_to_asic_id(member.port_id, member.link_id)
+            {
+                Ok(asic_id) => {
+                    if let Err(e) = self.switch.asic_hdl.mc_port_add(
+                        group_id,
+                        asic_id,
+                        replication_info.rid,
+                        replication_info.level1_excl_id,
+                    ) {
+                        error!(
+                                self.switch.log,
+                                "failed to add port during rollback: port={}, asic_id={}, group={}, error={:?}",
+                                member.port_id,
+                                asic_id,
+                                group_id,
+                                e
+                            );
+                        return Err(e.into());
+                    }
+                }
+                Err(e) => {
+                    error!(
+                            self.switch.log,
+                            "failed to resolve port link during rollback: port={}, link={}, error={:?}",
+                            member.port_id,
+                            member.link_id,
+                            e
+                        );
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> GroupUpdateRollbackContext<'a> {
+    /// Create rollback context for group update operations.
+    pub(crate) fn new(
+        switch: &'a Switch,
+        group_ip: IpAddr,
+        original_group: &'a MulticastGroup,
+    ) -> Self {
+        Self {
+            switch,
+            group_ip,
+            original_group,
+        }
+    }
+
+    /// Restore tables and return error.
+    pub(crate) fn rollback_and_restore<E>(&self, error: E) -> E {
+        if let Err(rollback_err) = self.restore_tables() {
+            error!(
+                self.switch.log,
+                "failed to restore tables during rollback: group={}, error={:?}",
+                self.group_ip,
+                rollback_err
+            );
+        }
+        error
+    }
+
+    /// Restore table entries to original state.
+    fn restore_tables(&self) -> DpdResult<()> {
+        let external_group_id = self.original_group.external_group_id();
+        let underlay_group_id = self.original_group.underlay_group_id();
+        let replication_info = &self.original_group.replication_info;
+        let vlan_id = self.original_group.ext_fwding.vlan_id;
+        let nat_target = self.original_group.int_fwding.nat_target;
+        let prev_members = self.original_group.members.to_vec();
+
+        if let Some(replication_info) = replication_info {
+            self.log_rollback_error(
+                "restore replication settings",
+                &format!("for group {}", self.group_ip),
+                update_replication_tables(
+                    self.switch,
+                    self.group_ip,
+                    external_group_id,
+                    underlay_group_id,
+                    replication_info,
+                ),
+            );
+        }
+
+        // Restore NAT settings
+        match (self.group_ip, nat_target) {
+            (IpAddr::V4(ipv4), Some(nat)) => {
+                self.log_rollback_error(
+                    "restore IPv4 NAT settings",
+                    &format!("for group {}", self.group_ip),
+                    table::mcast::mcast_nat::update_ipv4_entry(
+                        self.switch,
+                        ipv4,
+                        nat,
+                    ),
+                );
+            }
+            (IpAddr::V6(ipv6), Some(nat)) => {
+                self.log_rollback_error(
+                    "restore IPv6 NAT settings",
+                    &format!("for group {}", self.group_ip),
+                    table::mcast::mcast_nat::update_ipv6_entry(
+                        self.switch,
+                        ipv6,
+                        nat,
+                    ),
+                );
+            }
+            (IpAddr::V4(ipv4), None) => {
+                self.log_rollback_error(
+                    "remove IPv4 NAT settings",
+                    &format!("for group {}", self.group_ip),
+                    table::mcast::mcast_nat::del_ipv4_entry(self.switch, ipv4),
+                );
+            }
+            (IpAddr::V6(ipv6), None) => {
+                self.log_rollback_error(
+                    "remove IPv6 NAT settings",
+                    &format!("for group {}", self.group_ip),
+                    table::mcast::mcast_nat::del_ipv6_entry(self.switch, ipv6),
+                );
+            }
+        }
+
+        self.log_rollback_error(
+            "restore VLAN settings",
+            &format!("for group {}", self.group_ip),
+            update_fwding_tables(
+                self.switch,
+                self.group_ip,
+                external_group_id,
+                underlay_group_id,
+                &prev_members,
+                vlan_id,
+            ),
+        );
+        Ok(())
+    }
+
+    /// Rollback external group updates.
+    pub(crate) fn rollback_external<E>(
+        &self,
+        error: E,
+        new_sources: Option<&[IpSrc]>,
+    ) -> E {
+        if new_sources.is_some() {
+            self.collect_rollback_result("source filter restoration", || {
+                self.rollback_source_filters(new_sources, None)
+            });
+        }
+        error
+    }
+
+    /// Rollback internal group updates.
+    pub(crate) fn rollback_internal<E>(
+        &self,
+        error: E,
+        added_ports: &[MulticastGroupMember],
+        removed_ports: &[MulticastGroupMember],
+    ) -> E {
+        // Get replication info from original group
+        if let Some(replication_info) = &self.original_group.replication_info {
+            if let Err(rollback_err) = self.rollback_internal_update(
+                added_ports,
+                removed_ports,
+                replication_info,
+            ) {
+                error!(
+                    self.switch.log,
+                    "rollback failed for internal group update: group={}, error={:?}",
+                    self.group_ip,
+                    rollback_err
+                );
+            }
+        }
+        error
+    }
+}

--- a/dpd/src/mcast/validate.rs
+++ b/dpd/src/mcast/validate.rs
@@ -48,8 +48,8 @@ pub(crate) fn validate_nat_target(nat_target: NatTarget) -> DpdResult<()> {
 
     if !internal_nat_ip.is_admin_scoped_multicast() {
         return Err(DpdError::Invalid(format!(
-            r#"NAT target internal IP address {} is not a valid
-               site/admin-local or org-scoped multicast address"#,
+            "NAT target internal IP address {} is not a valid \
+             site/admin-local or org-scoped multicast address",
             nat_target.internal_ip
         )));
     }
@@ -89,8 +89,8 @@ fn validate_ipv4_multicast(
     if is_ssm(addr.into()) {
         if sources.is_none() || sources.unwrap().is_empty() {
             return Err(DpdError::Invalid(format!(
-                r#"{addr} is a Source-Specific Multicast address and
-                   requires at least one source to be defined"#,
+                "{addr} is a Source-Specific Multicast address and \
+                 requires at least one source to be defined",
             )));
         }
         // If sources are defined for an SSM address, it's valid
@@ -152,8 +152,8 @@ fn validate_ipv6_multicast(
     if is_ssm(addr.into()) {
         if sources.is_none() || sources.unwrap().is_empty() {
             return Err(DpdError::Invalid(format!(
-                r#"{addr} is an IPv6 Source-Specific Multicast address (ff3x::/32)
-                   and requires at least one source to be defined"#,
+                "{addr} is an IPv6 Source-Specific Multicast address (ff3x::/32) \
+                 and requires at least one source to be defined",
             )));
         }
         // If sources are defined for an IPv6 SSM address, it's valid
@@ -193,8 +193,8 @@ pub(crate) fn validate_not_admin_scoped_ipv6(addr: IpAddr) -> DpdResult<()> {
         if oxnet::Ipv6Net::new_unchecked(ipv6, 128).is_admin_scoped_multicast()
         {
             return Err(DpdError::Invalid(format!(
-                r#"{addr} is an admin-scoped multicast address and
-                   must be created via the internal multicast API"#,
+                "{addr} is an admin-scoped multicast address and \
+                 must be created via the internal multicast API",
             )));
         }
     }
@@ -239,8 +239,8 @@ fn validate_exact_source_address(ip: IpAddr) -> DpdResult<()> {
 fn validate_ipv4_source_address(ipv4: Ipv4Addr) -> DpdResult<()> {
     if ipv4.is_loopback() || ipv4.is_broadcast() || ipv4.is_unspecified() {
         return Err(DpdError::Invalid(format!(
-            r#"Source IP {ipv4} is not a valid source address
-               (loopback, broadcast, and unspecified addresses are not allowed)"#,
+            "Source IP {ipv4} is not a valid source address \
+             (loopback, broadcast, and unspecified addresses are not allowed)",
         )));
     }
     Ok(())
@@ -250,8 +250,8 @@ fn validate_ipv4_source_address(ipv4: Ipv4Addr) -> DpdResult<()> {
 fn validate_ipv6_source_address(ipv6: Ipv6Addr) -> DpdResult<()> {
     if ipv6.is_loopback() || ipv6.is_unspecified() {
         return Err(DpdError::Invalid(format!(
-            r#"Source IP {ipv6} is not a valid source address
-               (loopback and unspecified addresses are not allowed)"#,
+            "Source IP {ipv6} is not a valid source address \
+             (loopback and unspecified addresses are not allowed)",
         )));
     }
     Ok(())
@@ -271,8 +271,8 @@ fn validate_ipv4_source_subnet(subnet: Ipv4Net) -> DpdResult<()> {
     // Reject subnets with loopback or broadcast addresses
     if addr.is_loopback() || addr.is_broadcast() {
         return Err(DpdError::Invalid(format!(
-            r#"Source subnet {subnet} contains invalid address types
-               (loopback/broadcast) for source filtering"#,
+            "Source subnet {subnet} contains invalid address types \
+             (loopback/broadcast) for source filtering",
         )));
     }
 

--- a/dpd/src/mcast/validate.rs
+++ b/dpd/src/mcast/validate.rs
@@ -12,6 +12,12 @@ use oxnet::{Ipv4Net, Ipv6Net};
 use super::IpSrc;
 use crate::types::{DpdError, DpdResult};
 
+/// Check if an IP address is unicast (emulating the unstable std::net API).
+/// For IP addresses, unicast means simply "not multicast".
+const fn is_unicast(addr: IpAddr) -> bool {
+    !addr.is_multicast()
+}
+
 /// Validates if a multicast address is allowed for group creation.
 ///
 /// Returns a [`DpdResult`] indicating whether the address is valid or not.
@@ -19,6 +25,10 @@ pub(crate) fn validate_multicast_address(
     addr: IpAddr,
     sources: Option<&[IpSrc]>,
 ) -> DpdResult<()> {
+    // First validate that source addresses are unicast
+    validate_source_addresses(sources)?;
+
+    // Then validate the multicast address itself
     match addr {
         IpAddr::V4(ipv4) => validate_ipv4_multicast(ipv4, sources),
         IpAddr::V6(ipv6) => validate_ipv6_multicast(ipv6, sources),
@@ -83,7 +93,7 @@ fn validate_ipv4_multicast(
                 addr
             )));
         }
-        // If we have sources defined for an SSM address, it's valid
+        // If sources are defined for an SSM address, it's valid
         return Ok(());
     } else if sources.is_some() {
         // If this is not SSM but sources are defined, it's invalid
@@ -150,7 +160,7 @@ fn validate_ipv6_multicast(
                 addr
             )));
         }
-        // If we have sources defined for an IPv6 SSM address, it's valid
+        // If sources are defined for an IPv6 SSM address, it's valid
         return Ok(());
     } else if sources.is_some() {
         // If this is not SSM but sources are defined, it's invalid
@@ -194,6 +204,86 @@ pub(crate) fn validate_not_admin_scoped_ipv6(addr: IpAddr) -> DpdResult<()> {
             )));
         }
     }
+    Ok(())
+}
+
+/// Validates that source IP addresses are unicast.
+pub(crate) fn validate_source_addresses(
+    sources: Option<&[IpSrc]>,
+) -> DpdResult<()> {
+    let sources = match sources {
+        Some(sources) => sources,
+        None => return Ok(()),
+    };
+
+    for source in sources {
+        match source {
+            IpSrc::Exact(ip) => validate_exact_source_address(*ip)?,
+            IpSrc::Subnet(subnet) => validate_ipv4_source_subnet(*subnet)?,
+        }
+    }
+    Ok(())
+}
+
+/// Validates a single exact source IP address.
+fn validate_exact_source_address(ip: IpAddr) -> DpdResult<()> {
+    // First check if it's unicast (excludes multicast)
+    if !is_unicast(ip) {
+        return Err(DpdError::Invalid(format!(
+            "Source IP {} must be a unicast address (multicast addresses are not allowed)",
+            ip
+        )));
+    }
+
+    // Check for other problematic address types
+    match ip {
+        IpAddr::V4(ipv4) => validate_ipv4_source_address(ipv4),
+        IpAddr::V6(ipv6) => validate_ipv6_source_address(ipv6),
+    }
+}
+
+/// Validates IPv4 source addresses for problematic types.
+fn validate_ipv4_source_address(ipv4: Ipv4Addr) -> DpdResult<()> {
+    if ipv4.is_loopback() || ipv4.is_broadcast() || ipv4.is_unspecified() {
+        return Err(DpdError::Invalid(format!(
+            "Source IP {} is not a valid source address (loopback, broadcast, and unspecified addresses are not allowed)",
+            ipv4
+        )));
+    }
+    Ok(())
+}
+
+/// Validates IPv6 source addresses for problematic types.
+fn validate_ipv6_source_address(ipv6: Ipv6Addr) -> DpdResult<()> {
+    if ipv6.is_loopback() || ipv6.is_unspecified() {
+        return Err(DpdError::Invalid(format!(
+            "Source IP {} is not a valid source address (loopback and unspecified addresses are not allowed)",
+            ipv6
+        )));
+    }
+    Ok(())
+}
+
+/// Validates IPv4 source subnets for problematic address ranges.
+fn validate_ipv4_source_subnet(net: Ipv4Net) -> DpdResult<()> {
+    let addr = net.addr();
+
+    // Reject subnets that contain multicast addresses
+    if addr.is_multicast() {
+        return Err(DpdError::Invalid(format!(
+            "Source subnet {} contains multicast addresses and cannot be used as a source filter",
+            net
+        )));
+    }
+
+    // Reject subnets with loopback or broadcast addresses
+    if addr.is_loopback() || addr.is_broadcast() {
+        return Err(DpdError::Invalid(format!(
+            "Source subnet {} contains invalid address types (loopback/broadcast) for source filtering",
+            net
+        )));
+    }
+
     Ok(())
 }
 
@@ -456,5 +546,117 @@ mod tests {
         };
 
         assert!(validate_nat_target(mcast_nat_target).is_ok());
+    }
+
+    #[test]
+    fn test_validate_source_addresses() {
+        // Valid unicast IPv4 sources
+        let valid_ipv4_sources = vec![
+            IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))),
+            IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+        ];
+        assert!(validate_source_addresses(Some(&valid_ipv4_sources)).is_ok());
+
+        // Valid unicast IPv6 sources
+        let valid_ipv6_sources = vec![IpSrc::Exact(IpAddr::V6(Ipv6Addr::new(
+            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+        )))];
+        assert!(validate_source_addresses(Some(&valid_ipv6_sources)).is_ok());
+
+        // Valid subnet sources
+        let valid_subnet_sources = vec![
+            IpSrc::Subnet(Ipv4Net::from_str("192.168.1.0/24").unwrap()),
+            IpSrc::Subnet(Ipv4Net::from_str("10.0.0.0/8").unwrap()),
+        ];
+        assert!(validate_source_addresses(Some(&valid_subnet_sources)).is_ok());
+
+        // Invalid multicast IPv4 source
+        let invalid_mcast_ipv4 =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(224, 1, 1, 1)))];
+        assert!(validate_source_addresses(Some(&invalid_mcast_ipv4)).is_err());
+
+        // Invalid multicast IPv6 source
+        let invalid_mcast_ipv6 = vec![IpSrc::Exact(IpAddr::V6(Ipv6Addr::new(
+            0xff0e, 0, 0, 0, 0, 0, 0, 1,
+        )))];
+        assert!(validate_source_addresses(Some(&invalid_mcast_ipv6)).is_err());
+
+        // Invalid broadcast IPv4 source
+        let invalid_broadcast =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)))];
+        assert!(validate_source_addresses(Some(&invalid_broadcast)).is_err());
+
+        // Invalid loopback IPv4 source
+        let invalid_loopback_ipv4 =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))];
+        assert!(
+            validate_source_addresses(Some(&invalid_loopback_ipv4)).is_err()
+        );
+
+        // Invalid loopback IPv6 source
+        let invalid_loopback_ipv6 = vec![IpSrc::Exact(IpAddr::V6(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+        ))];
+        assert!(
+            validate_source_addresses(Some(&invalid_loopback_ipv6)).is_err()
+        );
+
+        // Invalid multicast subnet
+        let invalid_mcast_subnet =
+            vec![IpSrc::Subnet(Ipv4Net::from_str("224.0.0.0/24").unwrap())];
+        assert!(validate_source_addresses(Some(&invalid_mcast_subnet)).is_err());
+
+        // Invalid loopback subnet
+        let invalid_loopback_subnet =
+            vec![IpSrc::Subnet(Ipv4Net::from_str("127.0.0.0/8").unwrap())];
+        assert!(
+            validate_source_addresses(Some(&invalid_loopback_subnet)).is_err()
+        );
+
+        // No sources should be valid
+        assert!(validate_source_addresses(None).is_ok());
+
+        // Empty sources should be valid
+        assert!(validate_source_addresses(Some(&[])).is_ok());
+    }
+
+    #[test]
+    fn test_address_validation_with_source_validation() {
+        // Test that multicast address validation now includes source validation
+
+        // Valid case: SSM address with valid unicast sources
+        let valid_sources =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)))];
+        assert!(validate_multicast_address(
+            IpAddr::V4(Ipv4Addr::new(232, 1, 2, 3)),
+            Some(&valid_sources)
+        )
+        .is_ok());
+
+        // Invalid case: SSM address with multicast source (should fail source validation first)
+        let invalid_mcast_sources =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(224, 1, 1, 1)))];
+        let result = validate_multicast_address(
+            IpAddr::V4(Ipv4Addr::new(232, 1, 2, 3)),
+            Some(&invalid_mcast_sources),
+        );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be a unicast address"));
+
+        // Invalid case: SSM address with loopback source
+        let invalid_loopback_sources =
+            vec![IpSrc::Exact(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))];
+        let result = validate_multicast_address(
+            IpAddr::V4(Ipv4Addr::new(232, 1, 2, 3)),
+            Some(&invalid_loopback_sources),
+        );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("is not a valid source address"));
     }
 }

--- a/dpd/src/mcast/validate.rs
+++ b/dpd/src/mcast/validate.rs
@@ -48,7 +48,8 @@ pub(crate) fn validate_nat_target(nat_target: NatTarget) -> DpdResult<()> {
 
     if !internal_nat_ip.is_admin_scoped_multicast() {
         return Err(DpdError::Invalid(format!(
-            "NAT target internal IP address {} is not a valid site/admin-local or org-scoped multicast address",
+            r#"NAT target internal IP address {} is not a valid
+               site/admin-local or org-scoped multicast address"#,
             nat_target.internal_ip
         )));
     }
@@ -80,8 +81,7 @@ fn validate_ipv4_multicast(
     // Verify this is actually a multicast address
     if !addr.is_multicast() {
         return Err(DpdError::Invalid(format!(
-            "{} is not a multicast address",
-            addr
+            "{addr} is not a multicast address",
         )));
     }
 
@@ -89,8 +89,8 @@ fn validate_ipv4_multicast(
     if is_ssm(addr.into()) {
         if sources.is_none() || sources.unwrap().is_empty() {
             return Err(DpdError::Invalid(format!(
-                "{} is a Source-Specific Multicast address and requires at least one source to be defined",
-                addr
+                r#"{addr} is a Source-Specific Multicast address and
+                   requires at least one source to be defined"#,
             )));
         }
         // If sources are defined for an SSM address, it's valid
@@ -98,8 +98,7 @@ fn validate_ipv4_multicast(
     } else if sources.is_some() {
         // If this is not SSM but sources are defined, it's invalid
         return Err(DpdError::Invalid(format!(
-            "{} is not a Source-Specific Multicast address but sources were provided",
-            addr
+            "{addr} is not a Source-Specific Multicast address but sources were provided",
         )));
     }
 
@@ -117,8 +116,7 @@ fn validate_ipv4_multicast(
     for subnet in &reserved_subnets {
         if subnet.contains(addr) {
             return Err(DpdError::Invalid(format!(
-                "{} is in the reserved multicast subnet {}",
-                addr, subnet,
+                "{addr} is in the reserved multicast subnet {subnet}",
             )));
         }
     }
@@ -132,8 +130,7 @@ fn validate_ipv4_multicast(
 
     if specific_reserved.contains(&addr) {
         return Err(DpdError::Invalid(format!(
-            "{} is a specifically reserved multicast address",
-            addr
+            "{addr} is a specifically reserved multicast address",
         )));
     }
 
@@ -147,8 +144,7 @@ fn validate_ipv6_multicast(
 ) -> DpdResult<()> {
     if !addr.is_multicast() {
         return Err(DpdError::Invalid(format!(
-            "{} is not a multicast address",
-            addr
+            "{addr} is not a multicast address",
         )));
     }
 
@@ -156,8 +152,8 @@ fn validate_ipv6_multicast(
     if is_ssm(addr.into()) {
         if sources.is_none() || sources.unwrap().is_empty() {
             return Err(DpdError::Invalid(format!(
-                "{} is an IPv6 Source-Specific Multicast address (ff3x::/32) and requires at least one source to be defined",
-                addr
+                r#"{addr} is an IPv6 Source-Specific Multicast address (ff3x::/32)
+                   and requires at least one source to be defined"#,
             )));
         }
         // If sources are defined for an IPv6 SSM address, it's valid
@@ -165,8 +161,7 @@ fn validate_ipv6_multicast(
     } else if sources.is_some() {
         // If this is not SSM but sources are defined, it's invalid
         return Err(DpdError::Invalid(format!(
-            "{} is not a Source-Specific Multicast address but sources were provided",
-            addr
+            "{addr} is not a Source-Specific Multicast address but sources were provided",
         )));
     }
 
@@ -184,8 +179,7 @@ fn validate_ipv6_multicast(
     for subnet in &reserved_subnets {
         if subnet.contains(addr) {
             return Err(DpdError::Invalid(format!(
-                "{} is in the reserved multicast subnet {}",
-                addr, subnet
+                "{addr} is in the reserved multicast subnet {subnet}",
             )));
         }
     }
@@ -199,8 +193,8 @@ pub(crate) fn validate_not_admin_scoped_ipv6(addr: IpAddr) -> DpdResult<()> {
         if oxnet::Ipv6Net::new_unchecked(ipv6, 128).is_admin_scoped_multicast()
         {
             return Err(DpdError::Invalid(format!(
-                "{} is an admin-scoped multicast address and must be created via the internal multicast API",
-                addr
+                r#"{addr} is an admin-scoped multicast address and
+                   must be created via the internal multicast API"#,
             )));
         }
     }
@@ -230,8 +224,7 @@ fn validate_exact_source_address(ip: IpAddr) -> DpdResult<()> {
     // First check if it's unicast (excludes multicast)
     if !is_unicast(ip) {
         return Err(DpdError::Invalid(format!(
-            "Source IP {} must be a unicast address (multicast addresses are not allowed)",
-            ip
+            "Source IP {ip} must be a unicast address (multicast addresses are not allowed)",
         )));
     }
 
@@ -246,8 +239,8 @@ fn validate_exact_source_address(ip: IpAddr) -> DpdResult<()> {
 fn validate_ipv4_source_address(ipv4: Ipv4Addr) -> DpdResult<()> {
     if ipv4.is_loopback() || ipv4.is_broadcast() || ipv4.is_unspecified() {
         return Err(DpdError::Invalid(format!(
-            "Source IP {} is not a valid source address (loopback, broadcast, and unspecified addresses are not allowed)",
-            ipv4
+            r#"Source IP {ipv4} is not a valid source address
+               (loopback, broadcast, and unspecified addresses are not allowed)"#,
         )));
     }
     Ok(())
@@ -257,30 +250,29 @@ fn validate_ipv4_source_address(ipv4: Ipv4Addr) -> DpdResult<()> {
 fn validate_ipv6_source_address(ipv6: Ipv6Addr) -> DpdResult<()> {
     if ipv6.is_loopback() || ipv6.is_unspecified() {
         return Err(DpdError::Invalid(format!(
-            "Source IP {} is not a valid source address (loopback and unspecified addresses are not allowed)",
-            ipv6
+            r#"Source IP {ipv6} is not a valid source address
+               (loopback and unspecified addresses are not allowed)"#,
         )));
     }
     Ok(())
 }
 
 /// Validates IPv4 source subnets for problematic address ranges.
-fn validate_ipv4_source_subnet(net: Ipv4Net) -> DpdResult<()> {
-    let addr = net.addr();
+fn validate_ipv4_source_subnet(subnet: Ipv4Net) -> DpdResult<()> {
+    let addr = subnet.addr();
 
     // Reject subnets that contain multicast addresses
     if addr.is_multicast() {
         return Err(DpdError::Invalid(format!(
-            "Source subnet {} contains multicast addresses and cannot be used as a source filter",
-            net
+            "Source subnet {subnet} contains multicast addresses and cannot be used as a source filter",
         )));
     }
 
     // Reject subnets with loopback or broadcast addresses
     if addr.is_loopback() || addr.is_broadcast() {
         return Err(DpdError::Invalid(format!(
-            "Source subnet {} contains invalid address types (loopback/broadcast) for source filtering",
-            net
+            r#"Source subnet {subnet} contains invalid address types
+               (loopback/broadcast) for source filtering"#,
         )));
     }
 

--- a/dpd/src/table/mcast/mcast_replication.rs
+++ b/dpd/src/table/mcast/mcast_replication.rs
@@ -43,12 +43,12 @@ enum Ipv6Action {
 /// - external_mcast_grp: for replication to external/customer ports (mcast_grp_a)
 /// - underlay_mcast_grp: for replication to underlay/infrastructure ports (mcast_grp_b)
 ///
-/// Both groups are optional depending on the group's member configuration.
+/// Both groups are always allocated.
 pub(crate) fn add_ipv6_entry(
     s: &Switch,
     dst_addr: Ipv6Addr,
-    underlay_mcast_grp: Option<MulticastGroupId>,
-    external_mcast_grp: Option<MulticastGroupId>,
+    underlay_mcast_grp: MulticastGroupId,
+    external_mcast_grp: MulticastGroupId,
     replication_id: u16,
     level1_excl_id: u16,
     level2_excl_id: u16,
@@ -59,18 +59,11 @@ pub(crate) fn add_ipv6_entry(
         ));
     }
 
-    if underlay_mcast_grp.is_none() && external_mcast_grp.is_none() {
-        return Err(DpdError::McastGroupFailure(
-            "neither underlay nor external multicast group specified"
-                .to_string(),
-        ));
-    }
-
     let match_key = Ipv6MatchKey::new(dst_addr);
 
     let action_data = Ipv6Action::ConfigureIpv6 {
-        mcast_grp_a: external_mcast_grp.unwrap_or(0),
-        mcast_grp_b: underlay_mcast_grp.unwrap_or(0),
+        mcast_grp_a: external_mcast_grp,
+        mcast_grp_b: underlay_mcast_grp,
         rid: replication_id,
         level1_excl_id,
         level2_excl_id,
@@ -92,8 +85,8 @@ pub(crate) fn add_ipv6_entry(
 pub(crate) fn update_ipv6_entry(
     s: &Switch,
     dst_addr: Ipv6Addr,
-    underlay_mcast_grp: Option<MulticastGroupId>,
-    external_mcast_grp: Option<MulticastGroupId>,
+    underlay_mcast_grp: MulticastGroupId,
+    external_mcast_grp: MulticastGroupId,
     replication_id: u16,
     level1_excl_id: u16,
     level2_excl_id: u16,
@@ -104,18 +97,11 @@ pub(crate) fn update_ipv6_entry(
         ));
     }
 
-    if underlay_mcast_grp.is_none() && external_mcast_grp.is_none() {
-        return Err(DpdError::McastGroupFailure(
-            "neither underlay nor external multicast group specified"
-                .to_string(),
-        ));
-    }
-
     let match_key = Ipv6MatchKey::new(dst_addr);
 
     let action_data = Ipv6Action::ConfigureIpv6 {
-        mcast_grp_a: external_mcast_grp.unwrap_or(0),
-        mcast_grp_b: underlay_mcast_grp.unwrap_or(0),
+        mcast_grp_a: external_mcast_grp,
+        mcast_grp_b: underlay_mcast_grp,
         rid: replication_id,
         level1_excl_id,
         level2_excl_id,

--- a/dpd/src/types.rs
+++ b/dpd/src/types.rs
@@ -299,3 +299,9 @@ impl convert::From<common::network::VlanError> for DpdError {
         DpdError::Invalid(err.to_string())
     }
 }
+
+impl convert::From<dpd_types::mcast::Error> for DpdError {
+    fn from(err: dpd_types::mcast::Error) -> Self {
+        DpdError::Invalid(err.to_string())
+    }
+}

--- a/openapi/dpd.json
+++ b/openapi/dpd.json
@@ -7682,13 +7682,6 @@
               "$ref": "#/components/schemas/MulticastGroupMember"
             }
           },
-          "sources": {
-            "nullable": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpSrc"
-            }
-          },
           "tag": {
             "nullable": true,
             "type": "string"
@@ -7761,7 +7754,6 @@
             "$ref": "#/components/schemas/ExternalForwarding"
           },
           "external_group_id": {
-            "nullable": true,
             "type": "integer",
             "format": "uint16",
             "minimum": 0
@@ -7791,7 +7783,6 @@
             "type": "string"
           },
           "underlay_group_id": {
-            "nullable": true,
             "type": "integer",
             "format": "uint16",
             "minimum": 0
@@ -7799,9 +7790,11 @@
         },
         "required": [
           "ext_fwding",
+          "external_group_id",
           "group_ip",
           "int_fwding",
-          "members"
+          "members",
+          "underlay_group_id"
         ]
       },
       "MulticastGroupResponseResultsPage": {
@@ -7833,13 +7826,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MulticastGroupMember"
-            }
-          },
-          "sources": {
-            "nullable": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpSrc"
             }
           },
           "tag": {

--- a/openapi/dpd.json
+++ b/openapi/dpd.json
@@ -1105,7 +1105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MulticastGroupResponse"
+                  "$ref": "#/components/schemas/MulticastGroupExternalResponse"
                 }
               }
             }
@@ -1151,7 +1151,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MulticastGroupResponse"
+                  "$ref": "#/components/schemas/MulticastGroupExternalResponse"
                 }
               }
             }
@@ -1213,39 +1213,6 @@
           "required": []
         }
       },
-      "post": {
-        "summary": "Create an internal multicast group configuration.",
-        "description": "Internal groups are used for admin-scoped IPv6 multicast traffic that requires replication infrastructure. These groups support both external and underlay members with full replication capabilities.",
-        "operationId": "multicast_group_create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MulticastGroupCreateEntry"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MulticastGroupResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
       "delete": {
         "summary": "Reset all multicast group configurations.",
         "operationId": "multicast_reset",
@@ -1277,50 +1244,6 @@
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MulticastGroupResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "put": {
-        "summary": "Update an internal multicast group configuration for a given group IP address.",
-        "description": "Internal groups are used for admin-scoped IPv6 multicast traffic that requires replication infrastructure with external and underlay members.",
-        "operationId": "multicast_group_update",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_ip",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "ip"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MulticastGroupUpdateEntry"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "description": "successful operation",
@@ -1439,6 +1362,119 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/multicast/underlay-groups": {
+      "post": {
+        "summary": "Create an underlay (internal) multicast group configuration.",
+        "description": "Underlay groups are used for admin-scoped IPv6 multicast traffic that requires replication infrastructure. These groups support both external and underlay members with full replication capabilities.",
+        "operationId": "multicast_group_create_underlay",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MulticastGroupCreateUnderlayEntry"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MulticastGroupUnderlayResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/multicast/underlay-groups/{group_ip}": {
+      "get": {
+        "summary": "Get an underlay (internal) multicast group configuration by admin-scoped",
+        "description": "IPv6 address.\n\nUnderlay groups handle admin-scoped IPv6 multicast traffic with replication infrastructure for external and underlay members.",
+        "operationId": "multicast_group_get_underlay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "group_ip",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AdminScopedIpv6"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MulticastGroupUnderlayResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update an underlay (internal) multicast group configuration for a given",
+        "description": "group IP address.\n\nUnderlay groups are used for admin-scoped IPv6 multicast traffic that requires replication infrastructure with external and underlay members.",
+        "operationId": "multicast_group_update_underlay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "group_ip",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AdminScopedIpv6"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MulticastGroupUpdateUnderlayEntry"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MulticastGroupUnderlayResponse"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -5206,6 +5242,11 @@
   },
   "components": {
     "schemas": {
+      "AdminScopedIpv6": {
+        "description": "A validated admin-scoped IPv6 multicast address.\n\nAdmin-scoped addresses are ff04::/16, ff05::/16, or ff08::/16. These are used for internal/underlay multicast groups.",
+        "type": "string",
+        "format": "ipv6"
+      },
       "AnLtStatus": {
         "description": "A collection of the data involved in the autonegiation/link-training process",
         "type": "object",
@@ -7668,13 +7709,44 @@
           }
         }
       },
-      "MulticastGroupCreateEntry": {
+      "MulticastGroupCreateExternalEntry": {
+        "description": "A multicast group configuration for POST requests for external (to the rack) groups.",
+        "type": "object",
+        "properties": {
+          "external_forwarding": {
+            "$ref": "#/components/schemas/ExternalForwarding"
+          },
+          "group_ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "internal_forwarding": {
+            "$ref": "#/components/schemas/InternalForwarding"
+          },
+          "sources": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpSrc"
+            }
+          },
+          "tag": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "external_forwarding",
+          "group_ip",
+          "internal_forwarding"
+        ]
+      },
+      "MulticastGroupCreateUnderlayEntry": {
         "description": "A multicast group configuration for POST requests for internal (to the rack) groups.",
         "type": "object",
         "properties": {
           "group_ip": {
-            "type": "string",
-            "format": "ipv6"
+            "$ref": "#/components/schemas/AdminScopedIpv6"
           },
           "members": {
             "type": "array",
@@ -7692,16 +7764,24 @@
           "members"
         ]
       },
-      "MulticastGroupCreateExternalEntry": {
-        "description": "A multicast group configuration for POST requests for external (to the rack) groups.",
+      "MulticastGroupExternalResponse": {
+        "description": "Response structure for external multicast group operations. These groups handle IPv4 and non-admin IPv6 multicast via NAT targets.",
         "type": "object",
         "properties": {
+          "external_forwarding": {
+            "$ref": "#/components/schemas/ExternalForwarding"
+          },
+          "external_group_id": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
           "group_ip": {
             "type": "string",
             "format": "ip"
           },
-          "nat_target": {
-            "$ref": "#/components/schemas/NatTarget"
+          "internal_forwarding": {
+            "$ref": "#/components/schemas/InternalForwarding"
           },
           "sources": {
             "nullable": true,
@@ -7713,17 +7793,13 @@
           "tag": {
             "nullable": true,
             "type": "string"
-          },
-          "vlan_id": {
-            "nullable": true,
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
           }
         },
         "required": [
+          "external_forwarding",
+          "external_group_id",
           "group_ip",
-          "nat_target"
+          "internal_forwarding"
         ]
       },
       "MulticastGroupMember": {
@@ -7747,54 +7823,95 @@
         ]
       },
       "MulticastGroupResponse": {
-        "description": "Response structure for multicast group operations.",
-        "type": "object",
-        "properties": {
-          "ext_fwding": {
-            "$ref": "#/components/schemas/ExternalForwarding"
+        "description": "Unified response type for operations that return mixed group types.",
+        "oneOf": [
+          {
+            "description": "Response structure for underlay/internal multicast group operations. These groups handle admin-scoped IPv6 multicast with full replication.",
+            "type": "object",
+            "properties": {
+              "external_group_id": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "group_ip": {
+                "$ref": "#/components/schemas/AdminScopedIpv6"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "underlay"
+                ]
+              },
+              "members": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/MulticastGroupMember"
+                }
+              },
+              "tag": {
+                "nullable": true,
+                "type": "string"
+              },
+              "underlay_group_id": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "external_group_id",
+              "group_ip",
+              "kind",
+              "members",
+              "underlay_group_id"
+            ]
           },
-          "external_group_id": {
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
-          },
-          "group_ip": {
-            "type": "string",
-            "format": "ip"
-          },
-          "int_fwding": {
-            "$ref": "#/components/schemas/InternalForwarding"
-          },
-          "members": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MulticastGroupMember"
-            }
-          },
-          "sources": {
-            "nullable": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpSrc"
-            }
-          },
-          "tag": {
-            "nullable": true,
-            "type": "string"
-          },
-          "underlay_group_id": {
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
+          {
+            "description": "Response structure for external multicast group operations. These groups handle IPv4 and non-admin IPv6 multicast via NAT targets.",
+            "type": "object",
+            "properties": {
+              "external_forwarding": {
+                "$ref": "#/components/schemas/ExternalForwarding"
+              },
+              "external_group_id": {
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "group_ip": {
+                "type": "string",
+                "format": "ip"
+              },
+              "internal_forwarding": {
+                "$ref": "#/components/schemas/InternalForwarding"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "external"
+                ]
+              },
+              "sources": {
+                "nullable": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IpSrc"
+                }
+              },
+              "tag": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "external_forwarding",
+              "external_group_id",
+              "group_ip",
+              "internal_forwarding",
+              "kind"
+            ]
           }
-        },
-        "required": [
-          "ext_fwding",
-          "external_group_id",
-          "group_ip",
-          "int_fwding",
-          "members",
-          "underlay_group_id"
         ]
       },
       "MulticastGroupResponseResultsPage": {
@@ -7818,7 +7935,69 @@
           "items"
         ]
       },
-      "MulticastGroupUpdateEntry": {
+      "MulticastGroupUnderlayResponse": {
+        "description": "Response structure for underlay/internal multicast group operations. These groups handle admin-scoped IPv6 multicast with full replication.",
+        "type": "object",
+        "properties": {
+          "external_group_id": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "group_ip": {
+            "$ref": "#/components/schemas/AdminScopedIpv6"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MulticastGroupMember"
+            }
+          },
+          "tag": {
+            "nullable": true,
+            "type": "string"
+          },
+          "underlay_group_id": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "external_group_id",
+          "group_ip",
+          "members",
+          "underlay_group_id"
+        ]
+      },
+      "MulticastGroupUpdateExternalEntry": {
+        "description": "A multicast group update entry for PUT requests for external (to the rack) groups.",
+        "type": "object",
+        "properties": {
+          "external_forwarding": {
+            "$ref": "#/components/schemas/ExternalForwarding"
+          },
+          "internal_forwarding": {
+            "$ref": "#/components/schemas/InternalForwarding"
+          },
+          "sources": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IpSrc"
+            }
+          },
+          "tag": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "external_forwarding",
+          "internal_forwarding"
+        ]
+      },
+      "MulticastGroupUpdateUnderlayEntry": {
         "description": "Represents a multicast replication entry for PUT requests for internal (to the rack) groups.",
         "type": "object",
         "properties": {
@@ -7835,35 +8014,6 @@
         },
         "required": [
           "members"
-        ]
-      },
-      "MulticastGroupUpdateExternalEntry": {
-        "description": "A multicast group update entry for PUT requests for external (to the rack) groups.",
-        "type": "object",
-        "properties": {
-          "nat_target": {
-            "$ref": "#/components/schemas/NatTarget"
-          },
-          "sources": {
-            "nullable": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IpSrc"
-            }
-          },
-          "tag": {
-            "nullable": true,
-            "type": "string"
-          },
-          "vlan_id": {
-            "nullable": true,
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "nat_target"
         ]
       },
       "NatTarget": {


### PR DESCRIPTION
This change strengthens the multicast implementation with always-allocated group IDs, better API validation, and comprehensive test improvements for Omicron integration.

This update no longer generates multicast group IDs optionally. They are always allocated during group creation, following how multicast groups are configured in the Omicron CP

In Omicron, multicast groups are created first, without members, and then members are added as instances are configured for a multicast group.

Replication configuration is only written to tables when members are added, but IDs are always generated for the 1:1 mapping between underlay and external (overlay) associated groups.

Includes:
  * **Core ID Management Changes:**
    - Remove Option<MulticastGroupId> - IDs are always allocated during
      group creation
    - Establish 1:1 mapping between underlay and external (overlay) groups
    - External groups now use IDs from corresponding NAT target (Omicron
      keeps the true relational mapping)

  * **API Changes and Validation:**
    - Remove sources field from internal group
      APIs (MulticastGroupCreateEntry, MulticastGroupUpdateEntry)
    - New response types for External/Underlay: `MulticastUnderlayGroupResponse` and `MulticastExternalGroupResponse`, and unified for lists `MulticastGroupResponse`
    - Internal groups cannot have sources or NAT targets - cleaner
      separation of concerns
    - External groups retain sources for proper SSM (Source-Specific
      Multicast) validation
    - Now fail outright on reset if cleanup is not used properly, which
      helps on the Omicron side
    - Renaming API boundary structs to be consistent.
    - Integrate all the new types with the API trait that went in upstream
    - A new AdminScopedIpv6 Type to make the calls into dpd properly typed for internal underlay groups

  * **Rollback & Error Handling:**
    - The addition of a rollback module (and trait) for a more
      functional approach to rollback on creation or updates involving
      tables, ports, etc
    - Improved error propagation in test cleanup to catch resource leaks early
    - Better validation of group ID relationships to match tables and
      allocation states

  * **Test Infrastructure Improvements:**
    - Enhanced cleanup_test_group() to fail explicitly on deletion errors
      (prevents test pollution), and ensures proper 1:1 deletion mapping
    - New tests for rollback, empty members upon multicast group creation/update

  * **Replication Management:**
    - Configure replication only when groups have members (change made
      expecting empty groups in Omicron CP initially)
    - Reconfigure replication tables when transitioning between empty/populated groups

Key aspects this commit covers:

1. ID Management to match expectations in Omicron's multicast impl
2. Validation: Enhanced API validation, group ID relationship checks,
   SSM validation
3. Rollback: Reset operations now fail explicitly, better error propagation
4. Testing: Comprehensive test improvements, better error handling,
   standardized cleanup