### PR TITLE
Always check transcievers previously marked unsupported

### DIFF
--- a/dpd/src/transceivers/tofino_impl.rs
+++ b/dpd/src/transceivers/tofino_impl.rs
@@ -1133,7 +1133,7 @@ impl Switch {
                         port.as_qsfp().unwrap().transceiver,
                         Some(Transceiver::Unsupported)
                     ) {
-                        warn!(
+                        debug!(
                             log,
                             "transceiver was previously marked unsupported, \
                             we'll check again for support automatically";


### PR DESCRIPTION
- Check transceivers that aren't explicitly faulted on every pass through the monitoring loop. This ensures we always check those we thought were unsupported before, better handling spurious errors to check for support.
- Fixes #111