### PR TITLE
Initial parsable output flags for swadm 

### DIFF
--- a/swadm/src/main.rs
+++ b/swadm/src/main.rs
@@ -22,6 +22,7 @@ mod compliance;
 mod counters;
 mod link;
 mod nat;
+mod parsable_out;
 mod route;
 mod switchport;
 mod table;

--- a/swadm/src/parsable_out.rs
+++ b/swadm/src/parsable_out.rs
@@ -1,0 +1,60 @@
+#[derive(Clone, Debug, PartialEq)]
+pub enum OutputKind<T> {
+    Default {
+        header: bool,
+    },
+    Parseable {
+        header: bool,
+        fields: Vec<T>,
+        separator: ParseableOutputSeparator,
+    },
+}
+
+impl<T> OutputKind<T> {
+    pub fn with_header(header: bool) -> Self {
+        OutputKind::Default { header }
+    }
+
+    pub fn parseable(
+        header: bool,
+        fields: Vec<T>,
+        separator: Option<String>,
+    ) -> Self {
+        OutputKind::Parseable {
+            header,
+            fields,
+            separator: ParseableOutputSeparator::new(separator),
+        }
+    }
+
+    pub fn display_header(&self) -> bool {
+        match self {
+            Self::Default { header } => *header,
+            Self::Parseable { header, .. } => *header,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParseableOutputSeparator {
+    Default,
+    Custom(String),
+}
+
+impl ParseableOutputSeparator {
+    pub fn new(custom_value: Option<String>) -> Self {
+        match custom_value {
+            Some(value) => ParseableOutputSeparator::Custom(value),
+            None => ParseableOutputSeparator::Default,
+        }
+    }
+}
+
+impl ParseableOutputSeparator {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ParseableOutputSeparator::Default => ":",
+            ParseableOutputSeparator::Custom(s) => s.as_str(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds initial flags for parsable output to `swadm`. Flags for parsable output is supported for a small subset of commands, specifically the `sp xcvr` commands.

Currently this is a work in progress, modeling off of `ipadm` and https://github.com/oxidecomputer/transceiver-control/pull/410