### PR TITLE
[xtask] migrate to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8333,12 +8333,12 @@ dependencies = [
  "anyhow",
  "camino",
  "chrono",
+ "clap 4.5.21",
  "curl",
  "omicron-zone-package",
  "search_path",
  "serde",
  "serde_json",
- "structopt",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ bytes = "1.6"
 camino = { version = "1.1", features = ["serde1"] }
 cfg-if = "1"
 chrono = "0.4"
+clap = { version = "4.5.21", features = ["derive"] }
 colored = "2"
 csv = "1.3"
 curl = "0.4"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ search_path = "0.1.4"
 
 camino.workspace = true
 chrono.workspace = true
-structopt.workspace = true
+clap.workspace = true
 anyhow.workspace = true
 curl.workspace = true
 omicron-zone-package.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
-use structopt::*;
+use clap::{Parser, ValueEnum};
 
 mod codegen;
 
@@ -28,9 +28,10 @@ use linux as plat;
 
 // Possible formats for a bundled dendrite distro.  Currently the two "zone"
 // package formats are helios-only.
-#[derive(PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, ValueEnum)]
 pub enum DistFormat {
-    Native,  // .deb or .p5p, depending on the platform
+    #[default]
+    Native, // .deb or .p5p, depending on the platform
     Omicron, // package to be included in an omicron zone
     Global,  // package to run standalone in the global zone
 }
@@ -53,49 +54,39 @@ impl FromStr for DistFormat {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "xtask", about = "dendrite xtask support")]
+#[derive(Debug, Parser)]
+#[clap(name = "xtask", about = "dendrite xtask support")]
 enum Xtasks {
-    #[structopt(about = "compile a p4 program")]
+    /// compile a p4 program
     Codegen {
-        #[structopt(
-            short,
-            help = "name of p4 program to build",
-            default_value = "sidecar"
-        )]
+        /// name of p4 program to build
+        #[clap(short, default_value = "sidecar")]
         name: String,
 
-        #[structopt(
-            long,
-            help = "location of the tofino SDE",
-            default_value = "/opt/oxide/tofino_sde"
-        )]
+        /// location of the tofino SDE
+        #[clap(long, default_value = "/opt/oxide/tofino_sde")]
         sde: String,
 
-        #[structopt(long, help = "pipeline stages to build for")]
+        /// pipeline stages to build for
+        #[clap(long)]
         stages: Option<u8>,
     },
-    #[structopt(about = "build an installable dataplane controller package")]
+    /// build an installable dataplane controller package
     Dist {
-        #[structopt(long, help = "tofino_asic, tofino_stub, or softnpu")]
+        /// tofino_asic, tofino_stub, or softnpu
+        #[clap(long)]
         features: Option<String>,
 
-        #[structopt(
-            short,
-            help = "list of p4 programs to include",
-            default_value = "sidecar"
-        )]
+        /// list of p4 programs to include
+        #[clap(short, default_value = "sidecar")]
         names: Vec<String>,
 
-        #[structopt(short, long, help = "package release bits ")]
+        /// package release bits
+        #[clap(short, long)]
         release: bool,
 
-        #[structopt(
-            short,
-            long,
-            help = "package format: omicron, global, native",
-            default_value = "native"
-        )]
+        /// package format: omicron, global, native
+        #[clap(short, long, value_enum, default_value_t)]
         format: DistFormat,
     },
 }
@@ -248,7 +239,7 @@ fn collect_binaries<T: ToString>(
 )]
 #[tokio::main]
 async fn main() {
-    let task = Xtasks::from_args();
+    let task = Xtasks::parse();
     if let Err(e) = match task {
         Xtasks::Codegen { name, sde, stages } => {
             codegen::build(name, sde, stages)


### PR DESCRIPTION
I'm adding a new xtask, and it would be good to update to clap before I do that.
