### PR TITLE
chore: canonical exe path before validating.

### DIFF
--- a/asic/src/tofino_common/mod.rs
+++ b/asic/src/tofino_common/mod.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::fs;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -239,6 +240,10 @@ fn expect_name(mut inpath: PathBuf, expected: &str) -> AsicResult<PathBuf> {
 fn infer_p4_dir() -> AsicResult<String> {
     let mut exe_path = std::env::current_exe().map_err(|e| {
         AsicError::P4Missing(format!("looking up dpd path: {e:?}"))
+    })?;
+    // Canonicalize the path in case we're using a symlinked exe.
+    exe_path = fs::canonicalize(exe_path).map_err(|e| {
+        AsicError::P4Missing(format!("canonicalizing dpd path: {e:?}"))
     })?;
 
     // Pop off the trailing "dpd":


### PR DESCRIPTION
We validate that the dpd path lives at the expected location on start. However, this check can throw a false positive if we point to the exe via a symlink. This patch canonicalizes the exe path before validating so that we validate the real exe path, which may differ from env::current_exe().

Submitted to avoid a PATH workaround for running simulated omicron on macos. h/t @david-crespo.