### PR TITLE
Sync DHCPv6 addresses to ASIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,7 +2858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -3198,6 +3198,28 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 name = "libnet"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#3eb1a6ad0b713660b367ce275e0a3896eabe19d4"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "colored",
+ "dlpi 0.2.0 (git+https://github.com/oxidecomputer/dlpi-sys)",
+ "libc",
+ "num_enum 0.7.5",
+ "nvpair 0.5.0",
+ "nvpair-sys",
+ "oxnet",
+ "rand 0.9.2",
+ "rusty-doors",
+ "socket2 0.6.0",
+ "thiserror 2.0.16",
+ "tracing",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "libnet"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/netadm-sys#2cd6617e4a768521ad66a094d66e03390001ba9b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4170,7 +4192,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=795a1e0aeefb7a2c6fe4139779fdf66930d09b80#795a1e0aeefb7a2c6fe4139779fdf66930d09b80"
 dependencies = [
  "libc",
- "libnet",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "opte",
  "oxide-vpc",
  "postcard",
@@ -6683,6 +6705,7 @@ dependencies = [
  "ispf",
  "kstat-rs",
  "libc",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
  "lldpd-client",
  "omicron-common",
  "oxide-tokio-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ internal-dns-types = { git = "https://github.com/oxidecomputer/omicron", branch 
 ispf = { git = "https://github.com/oxidecomputer/ispf" }
 gateway-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 gateway-types = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }
 nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch= "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/dropshot-apis/src/main.rs
+++ b/dropshot-apis/src/main.rs
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright 2025 Oxide Computer Company
 
 use std::process::ExitCode;
 

--- a/tfportd/Cargo.toml
+++ b/tfportd/Cargo.toml
@@ -19,6 +19,7 @@ internet-checksum.workspace = true
 ispf.workspace = true
 libc.workspace = true
 kstat-rs.workspace = true
+libnet.workspace = true
 rand.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/tfportd/src/main.rs
+++ b/tfportd/src/main.rs
@@ -434,6 +434,12 @@ async fn main_impl() -> anyhow::Result<()> {
         None
     };
 
+    let g = global.clone();
+    task::spawn(async move {
+        info!(g.log, "spawning techport dhcpv6 sync task");
+        techport::sync_dhcp6(g).await
+    });
+
     // Spawn the task handling Sidecar packets on a separate thread.
     //
     // The code in here is _not_ async, and it's a lot of work to make it so.

--- a/xtask/src/external.rs
+++ b/xtask/src/external.rs
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright 2025 Oxide Computer Company
 
 //! External xtasks. (extasks?)
 


### PR DESCRIPTION
This PR adds a DHCPv6 address synchronizer to tfportd. This synchronizier checks both techport interfaces for DHCPv6 addresses every 30 seconds (same interval as the SLAAC synchronizer). If a DHCPv6 address is found on a techport, it is synchronized to the ASIC's local v6 address table.

Initial testing shows that this is all we need to support DHCPv6 for techport interfaces. This was tested on a racklette in the lab whose technician ports were connected to a management switch set up with a DHCPv6 server configuration.

Existing P4 plumbing for link-local multicast is sufficient to transit the required ICMPv6 router advertisement messaging and DHCPv6 messaging between FF02:1:2 and link-local addresses to and from the switch zone.

The end result is a racklette with a DHCPv6 address that is reachable from the management switch.

## TODO
- [ ] ~~Synchronize routes learned from RAs on techport interfaces?~~ This is not needed due to how the from-userspace path works in the P4 code.