### PR TITLE
disable test_port_settings_txn_sweep

### DIFF
--- a/dpd-client/tests/chaos_tests/port_settings.rs
+++ b/dpd-client/tests/chaos_tests/port_settings.rs
@@ -364,6 +364,15 @@ const OPERATION_FAILURE_RATE: f64 = 0.1;
 //  no meaningful consistency check to make. The important part in that case is
 //  we know bad state exists. What to do about that is outside the context of
 //  this test.
+//
+// NOTE
+// Disabling this test due to
+// - https://github.com/oxidecomputer/dendrite/issues/108
+// for the time being. The implementation of the port settings endpoint has
+// moved beyond it's design intent, and this test suite is no longer valid
+// and is just cauing CI pain.
+//
+#[ignore]
 #[tokio::test]
 async fn test_port_settings_txn_sweep() -> anyhow::Result<()> {
     let config = AsicConfig::uniform_set(TESTING_RADIX, OPERATION_FAILURE_RATE);


### PR DESCRIPTION
The implementation of the port settings apply function has moved beyond the original design intent. Due to that, this test is just causing pain in CI and is no longer meaningful. If we come back and revisit the port settings apply design, as some of the comments in #108 suggest, this test can be re-enabled.