### PR TITLE
p4: drop sctp in parser

### DIFF
--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -90,6 +90,7 @@ const bit<8> DROP_MULTICAST_PATH_FILTERED       = 0x17;
 const bit<8> DROP_GENEVE_OPTIONS_TOO_LONG       = 0x18;
 const bit<8> DROP_GENEVE_OPTION_MALFORMED       = 0x19;
 const bit<8> DROP_GENEVE_OPTION_UNKNOWN         = 0x1A;
+const bit<8> DROP_SCTP                          = 0x1B;
 // MAX(DROP_xxx) + 1
-const bit<32> DROP_REASON_MAX                   = 0x1B;
+const bit<32> DROP_REASON_MAX                   = 0x1C;
 

--- a/dpd/p4/headers.p4
+++ b/dpd/p4/headers.p4
@@ -14,6 +14,7 @@ const bit<16> ETHERTYPE_SIDECAR	= 0x0901;
 const bit<8> IPPROTO_ICMP	= 1;
 const bit<8> IPPROTO_TCP	= 6;
 const bit<8> IPPROTO_UDP	= 17;
+const bit<8> IPPROTO_SCTP	= 132;
 
 const bit<8> IPPROTO_HOPOPTS	= 0;
 const bit<8> IPPROTO_ROUTING	= 43;

--- a/dpd/p4/parser.p4
+++ b/dpd/p4/parser.p4
@@ -228,6 +228,7 @@ parser IngressParser(
 			IPPROTO_ICMP: parse_icmp;
 			IPPROTO_TCP: parse_tcp;
 			IPPROTO_UDP: parse_udp;
+			IPPROTO_SCTP: drop_sctp;
 			default: accept;
 		}
 	}
@@ -319,6 +320,7 @@ parser IngressParser(
 			IPPROTO_ICMPV6: parse_icmp;
 			IPPROTO_TCP: parse_tcp;
 			IPPROTO_UDP: parse_udp;
+			IPPROTO_SCTP: drop_sctp;
 			default: accept;
 		}
 	}
@@ -364,6 +366,12 @@ parser IngressParser(
 			GENEVE_UDP_PORT: parse_geneve;
 			default: accept;
 		}
+	}
+
+	state drop_sctp {
+		meta.drop_reason = DROP_SCTP;
+		meta.dropped = true;
+		transition accept;
 	}
 
 	state parse_geneve {

--- a/dpd/src/counters.rs
+++ b/dpd/src/counters.rs
@@ -198,6 +198,7 @@ enum DropReason {
     GeneveOptionsTooLong,
     GeneveOptionMalformed,
     GeneveOptionUnknown,
+    DropSctp,
 }
 
 impl TryFrom<u8> for DropReason {
@@ -232,6 +233,7 @@ impl TryFrom<u8> for DropReason {
             24 => Ok(DropReason::GeneveOptionsTooLong),
             25 => Ok(DropReason::GeneveOptionMalformed),
             26 => Ok(DropReason::GeneveOptionUnknown),
+            27 => Ok(DropReason::DropSctp),
             x => Err(format!("Unrecognized drop reason: {x}")),
         }
     }
@@ -278,6 +280,7 @@ fn reason_label(ctr: u8) -> Result<Option<String>, String> {
             "geneve_option_malformed".to_string()
         }
         DropReason::GeneveOptionUnknown => "geneve_option_unknown".to_string(),
+        DropReason::DropSctp => "drop_sctp".to_string(),
     };
     Ok(Some(label))
 }


### PR DESCRIPTION
Drops SCTP traffic at the parser for IPv4 and IPv6. This type of traffic is not supported for OPTE interfaces so there is no point in forwarding it through the NAT path, and we do not want this traffic heading to the switch zone.

If/when OPTE supports SCTP traffic, we'll want to allow SCTP on the NAT ingress path. But for now it makes the most sense to drop it at the front door. 