### PR TITLE
[meta] update to drift 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "drift"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cc7f4e6337c9c0d0402e2dccaeaea63fc38467a3e5ab3f465372dafce2cd89"
+checksum = "d46ae7066bba53a265e8412309dc64739d32c597d688f1938a44c01bd30629e7"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",


### PR DESCRIPTION
Drift 0.1.4 includes https://github.com/oxidecomputer/drift/pull/20 and https://github.com/oxidecomputer/drift/pull/22 -- the latter is particularly important because it can lead to false negatives where actually-incompatible APIs are marked as compatible.
