### PR TITLE
bump v6 lpm size

### DIFF
--- a/dpd-client/tests/integration_tests/table_tests.rs
+++ b/dpd-client/tests/integration_tests/table_tests.rs
@@ -48,12 +48,12 @@ use crate::integration_tests::common::prelude::*;
 #[cfg(feature = "multicast")]
 const IPV4_LPM_SIZE: usize = 7164; // ipv4 forwarding table
 #[cfg(not(feature = "multicast"))]
-const IPV4_LPM_SIZE: usize = 8187; // ipv4 forwarding table
+const IPV4_LPM_SIZE: usize = 8191; // ipv4 forwarding table
 
 #[cfg(feature = "multicast")]
 const IPV6_LPM_SIZE: usize = 1023; // ipv6 forwarding table
 #[cfg(not(feature = "multicast"))]
-const IPV6_LPM_SIZE: usize = 1023; // ipv6 forwarding table
+const IPV6_LPM_SIZE: usize = 8191; // ipv6 forwarding table
 
 const SWITCH_IPV4_ADDRS_SIZE: usize = 511; // ipv4 addrs assigned to our ports
 const SWITCH_IPV6_ADDRS_SIZE: usize = 511; // ipv6 addrs assigned to our ports

--- a/dpd/p4/constants.p4
+++ b/dpd/p4/constants.p4
@@ -11,7 +11,11 @@ const bit<16> L2_ISOLATED_FLAG = 0x8000;
 const int IPV4_NAT_TABLE_SIZE       = 1024; // nat routing table
 const int IPV6_NAT_TABLE_SIZE       = 1024; // nat routing table
 const int IPV4_LPM_SIZE             = 8192; // ipv4 forwarding table
+#ifdef MULTICAST
 const int IPV6_LPM_SIZE             = 1024; // ipv6 forwarding table
+#else
+const int IPV6_LPM_SIZE             = 8192; // ipv6 forwarding table
+#endif
 const int IPV4_ARP_SIZE             = 512;  // arp cache
 const int IPV6_NEIGHBOR_SIZE        = 512;  // ipv6 neighbor cache
 const int SWITCH_IPV4_ADDRS_SIZE    = 512;  // ipv4 addrs assigned to our ports


### PR DESCRIPTION
Brings the V6 routing tables up to 8291 entries, in line with V4 routing tables.

Something to note is that `Ingress.l3_router.Router6.lookup_idx.lookup` is now [split across 3 stages](https://buildomat.eng.oxide.computer/wg/0/artefact/01KR87Z12ZKA1BKSFR1P8QK635/0q7MSkcSxtZU1fLueTUEN7zmyAC8qlPy9maNOcYjenuVo7qK/01KR87Z99D3005VR1ZY9BFK48V/01KR88PTBPCFNP814YT6KK1CRA/mau.characterize.log).