### PR TITLE
dpd: log full error chain on failure to bind API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,12 +1566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "display-error-chain"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc2146e86bc19f52f4c064a64782f05f139ca464ed72937301631e73f8d6cf5"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,7 +1659,6 @@ dependencies = [
  "common 0.1.0",
  "console-subscriber",
  "csv",
- "display-error-chain",
  "dpd-api",
  "dpd-client 0.1.0",
  "dpd-types",
@@ -1700,6 +1693,7 @@ dependencies = [
  "signal-hook-tokio",
  "slog",
  "slog-async",
+ "slog-error-chain",
  "slog-term",
  "smf 0.10.0",
  "strum 0.27.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branc
 oxnet = { version = "0.1.6", default-features = false, features = ["schemars", "serde"] }
 propolis = { git = "https://github.com/oxidecomputer/propolis" }
 smf = { git = "https://github.com/illumos/smf-rs" }
+slog-error-chain = { git = "https://github.com/oxidecomputer/slog-error-chain", branch = "main" }
 softnpu-lib = { git = "https://github.com/oxidecomputer/softnpu" , package = "softnpu" , branch = "main"}
 tofino = { git = "https://github.com/oxidecomputer/tofino", branch = "main" }
 transceiver-controller = { git = "https://github.com/oxidecomputer/transceiver-control", branch = "main" }
@@ -71,7 +72,6 @@ clap = { version = "4.6", features = [ "derive" ] }
 colored = "3"
 csv = "1.3"
 curl = "0.4"
-display-error-chain = "0.2"
 dropshot = "0.17.1"
 dropshot-api-manager = "0.7.2"
 dropshot-api-manager-types = "0.7.2"

--- a/dpd/Cargo.toml
+++ b/dpd/Cargo.toml
@@ -37,7 +37,6 @@ chrono.workspace = true
 clap.workspace = true
 console-subscriber = { version = "0.5.0", optional = true }
 csv.workspace = true
-display-error-chain.workspace = true
 futures.workspace = true
 libc.workspace = true
 openssl.workspace = true
@@ -70,6 +69,7 @@ omicron-common.workspace = true
 oxide-tokio-rt.workspace = true
 oximeter.workspace = true
 oximeter-producer.workspace = true
+slog-error-chain.workspace = true
 smf.workspace = true
 transceiver-controller = { workspace = true, features = [ "api-traits" ] }
 scuffle = { workspace = true, features = ["smf-by-instance"] }

--- a/dpd/src/api_server.rs
+++ b/dpd/src/api_server.rs
@@ -66,6 +66,7 @@ use dpd_types::table;
 use dpd_types::table::TableParam;
 use dpd_types::transceivers::Transceiver;
 use dpd_types_versions::{v1, v7};
+use dropshot::BuildError;
 use dropshot::ClientErrorStatusCode;
 use dropshot::ClientSpecifiesVersionInHeader;
 use dropshot::EmptyScanParams;
@@ -83,6 +84,7 @@ use dropshot::TypedBody;
 use dropshot::VersionPolicy;
 use dropshot::WhichPage;
 use slog::{debug, error, info, o};
+use slog_error_chain::InlineErrorChain;
 use transceiver_controller::Datapath;
 use transceiver_controller::Monitors;
 
@@ -2993,7 +2995,7 @@ fn launch_server(
     switch: Arc<Switch>,
     addr: &SocketAddr,
     id: u32,
-) -> anyhow::Result<ApiServer> {
+) -> Result<ApiServer, BuildError> {
     let config_dropshot = dropshot::ConfigDropshot {
         bind_address: *addr,
         default_request_body_max_bytes: 10240,
@@ -3015,7 +3017,6 @@ fn launch_server(
         )))
         .build_starter()
         .map(|s| s.start())
-        .map_err(|e| anyhow::anyhow!(e.to_string()))
 }
 
 // Manage the set of api servers currently listening for requests.  When a
@@ -3056,8 +3057,8 @@ pub async fn api_server_manager(
                 }
                 Err(e) => {
                     error!(
-                        log,
-                        "failed to launch api server {id} on {addr}: {e:?}"
+                        log, "failed to launch api server {id} on {addr}";
+                        InlineErrorChain::new(&e),
                     );
                 }
             };

--- a/dpd/src/switch_identifiers.rs
+++ b/dpd/src/switch_identifiers.rs
@@ -8,9 +8,9 @@
 
 use std::sync::Arc;
 
-use display_error_chain::DisplayErrorChain;
 use dpd_types::switch_identifiers::SwitchIdentifiers;
 use slog::{debug, error, info, o};
+use slog_error_chain::InlineErrorChain;
 
 use crate::DpdResult;
 use crate::Switch;
@@ -64,7 +64,7 @@ pub(crate) async fn fetch_switch_identifiers_loop(
             .sp_local_switch_id()
             .await
             .map_err(|e| {
-                BackoffError::transient(DisplayErrorChain::new(&e).to_string())
+                BackoffError::transient(InlineErrorChain::new(&e).to_string())
             })?
             .into_inner();
         if type_ != gateway_types::component::SpType::Switch {
@@ -76,7 +76,7 @@ pub(crate) async fn fetch_switch_identifiers_loop(
             .sp_get(&type_, slot)
             .await
             .map_err(|e| {
-                BackoffError::transient(DisplayErrorChain::new(&e).to_string())
+                BackoffError::transient(InlineErrorChain::new(&e).to_string())
             })?
             .into_inner();
         Ok(SwitchIdentifiers {


### PR DESCRIPTION
Context for this is https://github.com/oxidecomputer/omicron/issues/10548, where we failed to bind but didn't log the underlying I/O error:

```
17:16:58.204Z ERRO dpd: failed to launch api server 1 on [::1]:33974: failed to bind to [::1]:33974
    
    Stack backtrace:
       0: anyhow::kind::Adhoc::new
    unit = api-server-manager
```