### PR TITLE
Fix FreeMap leak during recycle bin reclaim

### DIFF
--- a/dpd/src/freemap.rs
+++ b/dpd/src/freemap.rs
@@ -370,3 +370,21 @@ fn test_reclaim() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_reclaim_preserves_existing_freelist() -> anyhow::Result<()> {
+    let mut map = new_freemap(8);
+
+    // Leave a three-slot span in the freelist, allocate its first slot, then
+    // return that slot to the recycle bin.  The physically contiguous free
+    // range [5, 8) is now split between the recycle bin and freelist.
+    assert_eq!(map.alloc(5u16)?, 0);
+    let recycled = map.alloc(1u16)?;
+    assert_eq!(recycled, 5);
+    map.free(recycled, 1u16);
+
+    // Reclaim must preserve and coalesce both sources of free space.
+    assert_eq!(map.alloc(3u16)?, 5);
+
+    Ok(())
+}

--- a/dpd/src/freemap.rs
+++ b/dpd/src/freemap.rs
@@ -202,6 +202,8 @@ impl FreeMap {
             return false;
         }
 
+        let mut preexist = std::mem::take(&mut self.freelist);
+        reclaim.append(&mut preexist);
         reclaim.sort();
         let mut idx = 0;
         while idx < reclaim.len() - 1 {


### PR DESCRIPTION
During reclaim where we try to consolidate contiguous free slots, the entirety of the tracked free slots was overwritten by the recycle bins being consolidated. This resulted in all free items being leaked, as we lose all references to them when they're overwritten.

This PR modifies the reclaim operation to include the free list with the recycle bins when attempting consolidation, then assigning the combination to the free list. This ensures entries are not lost.
i.e.
Before: consolidate recycle bins, assign results to free list
After: consolidate recycle bins AND free list contents, assign results to free list