### PR TITLE
swadm: add long --speed to swadm link create

### DIFF
--- a/swadm/src/link.rs
+++ b/swadm/src/link.rs
@@ -489,7 +489,7 @@ pub struct LinkCreate {
     lane: Option<types::LinkId>,
 
     /// The speed for the new link.
-    #[clap(short = 's')]
+    #[clap(short = 's', long)]
     speed: PortSpeed,
 
     /// The error-correction scheme for the link.


### PR DESCRIPTION
Add long `--speed` option to `swadm link create` in addition to short `-s`.

The long `--speed`option was dropped in https://github.com/oxidecomputer/dendrite/pull/134

Dendrite changes were only recently integrated into `racktest` images via https://github.com/oxidecomputer/lengths-of-wire/pull/72 and forced changes in https://github.com/oxidecomputer/facade/pull/737.

Note, (1) we now have infrastructure in place to update `dendrite` in `racktest` images more easily so we should stay up to date and (2) intend to move more manufacturing sw to use Rust client libs.