### PR TITLE
Respect address tags in port_settings_*

### DIFF
--- a/dpd-client/tests/chaos_tests/port_settings.rs
+++ b/dpd-client/tests/chaos_tests/port_settings.rs
@@ -9,18 +9,24 @@ use super::harness::{
     new_dpd_client, run_dpd,
 };
 use super::util::{link_list_ipv4, link_list_ipv6};
+use crate::chaos_tests::harness;
+use crate::chaos_tests::util::HttpResponseCheck;
+use crate::chaos_tests::util::IpRng;
+
+use anyhow::bail;
 use asic::chaos::{AsicConfig, Chaos, TableChaos};
 use asic::table_chaos;
 use common::table::TableType;
 use dpd_client::types::{
-    LinkCreate, LinkId, LinkSettings, PortFec, PortId, PortSettings, PortSpeed,
+    Ipv4Entry, Ipv6Entry, LinkCreate, LinkId, LinkSettings, PortFec, PortId,
+    PortSettings, PortSpeed,
 };
 use dpd_client::{Client, ROLLBACK_FAILURE_ERROR_CODE};
 use http::status::StatusCode;
 use pretty_assertions::{Comparison, assert_eq};
 use rand::Rng;
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use tokio::time::Duration;
@@ -31,6 +37,17 @@ const TESTING_RADIX: usize = 33;
 // we give up?
 const RETRY_INTERVAL: Duration = Duration::from_millis(200);
 const RETRY_MAX: Duration = Duration::from_secs(5);
+
+/// A `LinkCreate` config with common defaults.
+const LINK_CREATE: LinkCreate = LinkCreate {
+    lane: None,
+    autoneg: false,
+    kr: false,
+    speed: PortSpeed::Speed100G,
+    fec: Some(PortFec::None),
+    tx_eq: None,
+    allow_ddm_traffic: false,
+};
 
 #[cfg(test)]
 mod retry {
@@ -83,18 +100,7 @@ async fn test_basic_autoneg_chaos() -> anyhow::Result<()> {
     let (_guard, client) = init_harness("autoneg", &config);
 
     let err = client
-        .link_create(
-            &"qsfp0".parse().unwrap(),
-            &LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: false,
-                speed: PortSpeed::Speed100G,
-                fec: Some(PortFec::None),
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
-        )
+        .link_create(&"qsfp0".parse().unwrap(), &LINK_CREATE)
         .await
         .expect_err("Expected error on create");
 
@@ -122,15 +128,7 @@ async fn test_port_settings_addr_fail_1() -> anyhow::Result<()> {
     settings.links.insert(
         "0".into(),
         LinkSettings {
-            params: LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: false,
-                fec: Some(PortFec::None),
-                speed: PortSpeed::Speed100G,
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
+            params: LINK_CREATE,
             addrs: vec!["203.0.113.47".parse().unwrap()],
         },
     );
@@ -164,15 +162,7 @@ async fn test_port_settings_addr_success_1() -> anyhow::Result<()> {
     settings.links.insert(
         "0".into(),
         LinkSettings {
-            params: LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: true,
-                fec: Some(PortFec::None),
-                speed: PortSpeed::Speed100G,
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
+            params: LinkCreate { kr: true, ..LINK_CREATE },
             addrs: vec!["203.0.113.47".parse().unwrap()],
         },
     );
@@ -204,15 +194,7 @@ async fn test_port_settings_addr_success_multi() -> anyhow::Result<()> {
     settings.links.insert(
         "0".into(),
         LinkSettings {
-            params: LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: true,
-                fec: Some(PortFec::None),
-                speed: PortSpeed::Speed100G,
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
+            params: LinkCreate { kr: true, ..LINK_CREATE },
             addrs: vec!["203.0.113.47".parse().unwrap()],
         },
     );
@@ -234,15 +216,7 @@ async fn test_port_settings_addr_success_multi() -> anyhow::Result<()> {
     settings.links.insert(
         "0".into(),
         LinkSettings {
-            params: LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: true,
-                fec: Some(PortFec::None),
-                speed: PortSpeed::Speed100G,
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
+            params: LinkCreate { kr: true, ..LINK_CREATE },
             addrs: vec![
                 "203.0.113.46".parse().unwrap(),
                 "203.0.113.48".parse().unwrap(),
@@ -275,15 +249,7 @@ async fn test_port_settings_addr_success_multi() -> anyhow::Result<()> {
     settings.links.insert(
         "0".into(),
         LinkSettings {
-            params: LinkCreate {
-                lane: None,
-                autoneg: false,
-                kr: true,
-                fec: Some(PortFec::None),
-                speed: PortSpeed::Speed100G,
-                tx_eq: None,
-                allow_ddm_traffic: false,
-            },
+            params: LinkCreate { kr: true, ..LINK_CREATE },
             addrs: vec![
                 "203.0.113.47".parse().unwrap(),
                 "fd00:1701::d".parse().unwrap(),
@@ -551,4 +517,528 @@ fn random_port_settings() -> PortSettings {
             LinkSettings { params, addrs },
         )]),
     }
+}
+
+const TAG1: &str = "chaos1";
+const TAG2: &str = "chaos2";
+
+/// Verifies tagged port_settings_apply actions don't affect
+/// resources from other tags.
+#[tokio::test]
+async fn settings_apply_respects_tags() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("settings_apply_respects_tags", &no_failures);
+
+    let mut rng = IpRng::new(12345);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id =
+        client.link_create(&port_id, &LINK_CREATE).await?.into_inner();
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+    let tag2 = TestAddrs::new(
+        &mut rng,
+        TAG2.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    tag1.create_addrs().await?;
+    tag2.apply_addrs().await?;
+
+    tag1.verify_addrs_exist(Verify::NonExhaustive).await?;
+    tag2.verify_addrs_exist(Verify::NonExhaustive).await?;
+
+    client
+        .port_settings_apply(
+            &port_id,
+            Some(TAG2),
+            &PortSettings {
+                links: HashMap::from([(
+                    link_id.to_string(),
+                    LinkSettings { params: LINK_CREATE, addrs: Vec::new() },
+                )]),
+            },
+        )
+        .await?;
+
+    tag1.verify_addrs_exist(Verify::Exhaustive).await?;
+
+    Ok(())
+}
+
+/// Verifies tagged address_*_create and delete don't affect
+/// resources under different tags.
+#[tokio::test]
+async fn address_cmds_respect_tags() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("address_cmds_respect_tags", &no_failures);
+
+    let mut rng = IpRng::new(54321);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id = LinkId(0);
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+    let tag2 = TestAddrs::new(
+        &mut rng,
+        TAG2.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    tag2.apply_addrs().await?;
+
+    client
+        .link_ipv4_create(
+            &port_id,
+            &link_id,
+            &Ipv4Entry { addr: tag2.v4_entry.addr, tag: TAG1.to_string() },
+        )
+        .await
+        .expect_err(
+            "Registering the same address under different tags should fail",
+        )
+        .expect_status(StatusCode::CONFLICT);
+
+    tag1.create_addrs().await?;
+
+    tag1.verify_addrs_exist(Verify::NonExhaustive).await?;
+    tag2.verify_addrs_exist(Verify::NonExhaustive).await?;
+
+    client.link_ipv4_delete(&port_id, &link_id, &tag1.v4_entry.addr).await?;
+    client.link_ipv6_delete(&port_id, &link_id, &tag1.v6_entry.addr).await?;
+
+    tag2.verify_addrs_exist(Verify::Exhaustive).await?;
+    tag1.verify_addrs_exist(Verify::NonExhaustive)
+        .await
+        .expect_err("tag1 addresses should have been deleted");
+
+    Ok(())
+}
+
+/// Verifies the current known behavior of port_settings_clear, which
+/// is to delete the link and all its config from the port.
+///
+/// This test isn't necessarily endorsing the implementation, but
+/// it does seek to track API's current behavior.
+#[tokio::test]
+async fn settings_clear_ignores_tags() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("settings_clear_ignores_tags", &no_failures);
+
+    let mut rng = IpRng::new(1010101);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id =
+        client.link_create(&port_id, &LINK_CREATE).await?.into_inner();
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+    let tag2 = TestAddrs::new(
+        &mut rng,
+        TAG2.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    tag1.create_addrs().await?;
+    tag2.apply_addrs().await?;
+
+    tag1.verify_addrs_exist(Verify::NonExhaustive).await?;
+    tag2.verify_addrs_exist(Verify::NonExhaustive).await?;
+
+    // Tag2 means nothing here
+    client.port_settings_clear(&port_id, Some(TAG2)).await?;
+
+    tag1.verify_addrs_exist(Verify::Exhaustive).await.expect_err(
+        "Addresses do not exist because we cleared the port settings.",
+    );
+    tag2.verify_addrs_exist(Verify::NonExhaustive).await.expect_err(
+        "Addresses do not exist because we cleared the port settings.",
+    );
+
+    Ok(())
+}
+
+/// Verifies that link address creation fails when that
+/// address has already been registered (under another tag).
+#[tokio::test]
+async fn create_addr_rejects_overwrites() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("create_addr_overwrite_rejected", &no_failures);
+    let mut rng = IpRng::new(1433);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id =
+        client.link_create(&port_id, &LINK_CREATE).await?.into_inner();
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    tag1.apply_addrs().await?;
+
+    client
+        .link_ipv4_create(&port_id, &link_id, &tag1.v4_entry)
+        .await
+        .expect_err("Duplicate ipv4 registration fails")
+        .expect_status(StatusCode::CONFLICT);
+
+    client
+        .link_ipv6_create(&port_id, &link_id, &tag1.v6_entry)
+        .await
+        .expect_err("Duplicate ipv6 registration fails")
+        .expect_status(StatusCode::CONFLICT);
+
+    client
+        .link_ipv4_create(
+            &port_id,
+            &link_id,
+            &Ipv4Entry { addr: tag1.v4_entry.addr, tag: TAG2.to_string() },
+        )
+        .await
+        .expect_err("Cross-tag ipv4 registration fails")
+        .expect_status(StatusCode::CONFLICT);
+
+    client
+        .link_ipv6_create(
+            &port_id,
+            &link_id,
+            &Ipv6Entry { addr: tag1.v6_entry.addr, tag: TAG2.to_string() },
+        )
+        .await
+        .expect_err("Cross-tag ipv6 registration fails")
+        .expect_status(StatusCode::CONFLICT);
+
+    // The idempotent API necessarily accepts duplicate registrations.
+    tag1.apply_addrs().await?;
+
+    Ok(())
+}
+
+/// Verifies deletion fails when the address does not exist.
+#[tokio::test]
+async fn deleted_address_must_exist() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("delete_addr_conflicts", &no_failures);
+    let mut rng = IpRng::new(1516);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id = LinkId(0);
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    tag1.apply_addrs().await?;
+
+    client
+        .link_ipv4_delete(&port_id, &link_id, &rng.unique_ipv4())
+        .await
+        .expect_err("Deleting a non-existent IPv4 addr fails")
+        .expect_status(StatusCode::NOT_FOUND);
+
+    client
+        .link_ipv6_delete(&port_id, &link_id, &rng.unique_ipv6())
+        .await
+        .expect_err("Deleting a non-existent IPv6 addr fails")
+        .expect_status(StatusCode::NOT_FOUND);
+
+    // Deletion is not currently tagged, so there's no way/reason to test
+    // tag conflicts.
+
+    client.link_ipv4_delete(&port_id, &link_id, &tag1.v4_entry.addr).await?;
+    client.link_ipv6_delete(&port_id, &link_id, &tag1.v6_entry.addr).await?;
+    tag1.verify_addrs_exist(Verify::NonExhaustive)
+        .await
+        .expect_err("Addresses were deleted");
+
+    Ok(())
+}
+
+/// One tagged `port_settings_apply` can delete a link created
+/// by another tag's `port_settings_apply`. This isn't functionality
+/// we necessarily want, but we should also never exercise it in practice.
+/// Since it's a subtle footgun, this test at least documents its existence
+/// and observes if this ever changes.
+#[tokio::test]
+async fn apply_implicit_delete() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("apply_implicit_delete", &no_failures);
+    let mut rng = IpRng::new(1548);
+    let port_id: PortId = "qsfp0".parse()?;
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        LinkId(1),
+    );
+
+    let tag2 = TestAddrs::new(
+        &mut rng,
+        TAG2.to_string(),
+        &client,
+        port_id.clone(),
+        LinkId(2),
+    );
+
+    tag1.apply_addrs().await?;
+    tag1.verify_addrs_exist(Verify::Exhaustive).await?;
+
+    tag2.apply_addrs().await?;
+
+    tag1.verify_addrs_exist(Verify::NonExhaustive)
+        .await
+        .expect_err("Link 1 was deleted");
+    tag2.verify_addrs_exist(Verify::Exhaustive).await?;
+
+    Ok(())
+}
+
+/// port_settings_apply fails if it would overwrite an address
+/// belonging to another tag. Again, this should not arise in
+/// practice, but successful rollback is important in such cases.
+#[tokio::test]
+async fn apply_fails_on_tag_conflict() -> anyhow::Result<()> {
+    let no_failures = AsicConfig::uniform_set(TESTING_RADIX, 0.);
+    let (_guard, client) =
+        harness::init_harness("apply_tag_conflict", &no_failures);
+    let mut rng = IpRng::new(1616);
+    let port_id: PortId = "qsfp0".parse()?;
+    let link_id = LinkId(0);
+
+    let tag1 = TestAddrs::new(
+        &mut rng,
+        TAG1.to_string(),
+        &client,
+        port_id.clone(),
+        link_id,
+    );
+
+    client.link_create(&port_id, &LINK_CREATE).await?;
+    client
+        .link_ipv4_create(
+            &port_id,
+            &link_id,
+            &Ipv4Entry { addr: tag1.v4_entry.addr, tag: TAG2.to_string() },
+        )
+        .await?;
+    client
+        .link_ipv6_create(
+            &port_id,
+            &link_id,
+            &Ipv6Entry { addr: tag1.v6_entry.addr, tag: TAG2.to_string() },
+        )
+        .await?;
+
+    tag1.apply_addrs()
+        .await
+        .expect_err("Addresses belong to another tag")
+        .expect_status(StatusCode::CONFLICT);
+
+    client.link_ipv4_delete(&port_id, &link_id, &tag1.v4_entry.addr).await?;
+
+    tag1.apply_addrs()
+        .await
+        .expect_err("IPv6 address belongs to another tag")
+        .expect_status(StatusCode::CONFLICT);
+
+    client.link_ipv6_delete(&port_id, &link_id, &tag1.v6_entry.addr).await?;
+
+    tag1.apply_addrs().await?;
+    tag1.verify_addrs_exist(Verify::Exhaustive).await?;
+
+    Ok(())
+}
+
+/// This struct simplifies repetitive CRUD operations
+/// on tagged links with random address registrations.
+struct TestAddrs<'a> {
+    v4_entry: Ipv4Entry,
+    v6_entry: Ipv6Entry,
+    client: &'a Client,
+    port_id: PortId,
+    link_id: LinkId,
+}
+
+impl<'a> TestAddrs<'a> {
+    /// Creates a new instance with a random IPv4 and IPv6 address
+    /// for this port and link.
+    fn new(
+        rng: &mut IpRng,
+        tag: String,
+        client: &'a Client,
+        port_id: PortId,
+        link_id: LinkId,
+    ) -> Self {
+        Self {
+            v4_entry: Ipv4Entry { addr: rng.unique_ipv4(), tag: tag.clone() },
+            v6_entry: Ipv6Entry { addr: rng.unique_ipv6(), tag },
+            client,
+            port_id,
+            link_id,
+        }
+    }
+
+    /// Adds both tagged addresses to this link using dpd's `link_*_create` endpoints.
+    async fn create_addrs(&self) -> anyhow::Result<()> {
+        self.client
+            .link_ipv4_create(&self.port_id, &self.link_id, &self.v4_entry)
+            .await?;
+        self.client
+            .link_ipv6_create(&self.port_id, &self.link_id, &self.v6_entry)
+            .await?;
+        Ok(())
+    }
+
+    /// Adds both tagged addresses to this link using dpd's `port_settings_apply` endpoint.
+    async fn apply_addrs(
+        &self,
+    ) -> Result<(), dpd_client::Error<dpd_client::types::Error>> {
+        self.client
+            .port_settings_apply(
+                &self.port_id,
+                Some(&self.v4_entry.tag),
+                &PortSettings {
+                    links: HashMap::from([(
+                        self.link_id.to_string(),
+                        LinkSettings {
+                            params: LINK_CREATE,
+                            addrs: vec![
+                                self.v4_entry.addr.into(),
+                                self.v6_entry.addr.into(),
+                            ],
+                        },
+                    )]),
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Fetches this tag's addresses using `link_*_list` and `port_settings_get`.
+    /// Returns Err if both addresses are not found.
+    /// If `scope == Verify::Exhaustive`, returns Err if other addresses
+    /// are found on the link besides those in `self`.
+    async fn verify_addrs_exist(&self, scope: Verify) -> anyhow::Result<()> {
+        let v4 = self
+            .client
+            .link_ipv4_list(&self.port_id, &self.link_id, None, None)
+            .await?
+            .into_inner();
+        let v6 = self
+            .client
+            .link_ipv6_list(&self.port_id, &self.link_id, None, None)
+            .await?
+            .into_inner();
+
+        if !v4.items.contains(&self.v4_entry) {
+            bail!(
+                "Entry {:?} not found in listed addresses: {:?}",
+                self.v4_entry,
+                v4.items
+            );
+        }
+
+        if !v6.items.contains(&self.v6_entry) {
+            bail!(
+                "Entry {:?} not found in listed addresses: {:?}",
+                self.v6_entry,
+                v6.items
+            );
+        }
+
+        if scope == Verify::Exhaustive {
+            anyhow::ensure!(&v4.items == std::slice::from_ref(&self.v4_entry));
+        }
+
+        if scope == Verify::Exhaustive {
+            anyhow::ensure!(&v6.items == std::slice::from_ref(&self.v6_entry));
+        }
+
+        // Verify the port_settings endpoint returns the same.
+        let mut settings = self
+            .client
+            .port_settings_get(&self.port_id, Some(&self.v4_entry.tag))
+            .await?
+            .into_inner();
+
+        let Some(mut settings) =
+            settings.links.remove(&self.link_id.to_string()).map(|s| s.addrs)
+        else {
+            bail!(
+                "port_settings_get should return the target link id({:?}): found {settings:?}",
+                self.link_id
+            );
+        };
+
+        let mut listed = v4
+            .items
+            .into_iter()
+            .filter_map(|entry| {
+                (entry.tag == self.v4_entry.tag)
+                    .then(|| IpAddr::from(entry.addr))
+            })
+            .chain(v6.items.into_iter().filter_map(|entry| {
+                (entry.tag == self.v6_entry.tag)
+                    .then(|| IpAddr::from(entry.addr))
+            }))
+            .collect::<Vec<_>>();
+
+        listed.sort();
+        settings.sort();
+
+        if listed != settings {
+            bail!(
+                "Tagged address sources disagree: link_*_list({listed:?}) v. port_settings_get({settings:?})",
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Informs the behavior of address registration verification.
+#[derive(Debug, PartialEq, Eq)]
+enum Verify {
+    /// Expect that the target resources are the only of their
+    /// kind on this link regardless of tag.
+    Exhaustive,
+
+    /// Expect that the target resources exist on the link, but
+    /// resources from other tags may also exist.
+    NonExhaustive,
 }

--- a/dpd-client/tests/chaos_tests/util.rs
+++ b/dpd-client/tests/chaos_tests/util.rs
@@ -4,9 +4,19 @@
 //
 // Copyright 2025 Oxide Computer Company
 
-use dpd_client::Client;
-use dpd_client::types::{Ipv4Entry, Ipv6Entry};
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
+
 use futures::TryStreamExt;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use dpd_client::Client;
+use dpd_client::types::Ipv4Entry;
+use dpd_client::types::Ipv6Entry;
 
 pub(crate) async fn link_list_ipv4(
     client: &Client,
@@ -36,4 +46,79 @@ pub(crate) async fn link_list_ipv6(
         )
         .try_collect::<Vec<Ipv6Entry>>()
         .await
+}
+
+/// A random IP address generator.
+pub struct IpRng {
+    rng: StdRng,
+    claimed: HashSet<IpAddr>,
+}
+
+impl IpRng {
+    /// Creates a new ip address generator from the given seed.
+    pub fn new(seed: u64) -> Self {
+        Self { rng: StdRng::seed_from_u64(seed), claimed: HashSet::default() }
+    }
+
+    /// Returns a random IPv4 address that this instance
+    /// has never created before.
+    pub fn unique_ipv4(&mut self) -> Ipv4Addr {
+        Self::roll_unique(&mut self.claimed, || {
+            Ipv4Addr::from_bits(self.rng.random())
+        })
+    }
+
+    /// Returns a random IPv6 address that this instance
+    /// has never created before.
+    pub fn unique_ipv6(&mut self) -> Ipv6Addr {
+        Self::roll_unique(&mut self.claimed, || {
+            Ipv6Addr::from_bits(self.rng.random())
+        })
+    }
+
+    fn roll_unique<T>(
+        tracker: &mut HashSet<IpAddr>,
+        mut random_addr: impl FnMut() -> T,
+    ) -> T
+    where
+        T: Into<IpAddr> + Copy,
+    {
+        loop {
+            // Executes infinitely if we've already generated the entire
+            // IPv4 or IPv6 address space, in which case the offending test
+            // has earned a more bespoke solution :)
+            let addr = random_addr();
+            if tracker.insert(addr.into()) {
+                return addr;
+            }
+        }
+    }
+}
+
+/// Simplifies validating dropshot client output.
+pub trait HttpResponseCheck: Sized {
+    /// Panics if the status code within `self` does not match
+    /// the given code.
+    fn expect_status(self, code: reqwest::StatusCode) -> Self;
+}
+
+impl HttpResponseCheck for dpd_client::Error<dpd_client::types::Error> {
+    fn expect_status(self, code: reqwest::StatusCode) -> Self {
+        assert_eq!(self.status(), Some(code), "Unexpected HTTP status code");
+        self
+    }
+}
+
+#[cfg(test)]
+mod util_tests {
+    use crate::chaos_tests::util::IpRng;
+
+    /// Basic check on unique ipv6 address generation.
+    #[test]
+    fn unique_v6() {
+        let mut rng = IpRng::new(7);
+        let one = rng.unique_ipv6();
+        let two = rng.unique_ipv6();
+        assert_ne!(one, two);
+    }
 }

--- a/dpd/src/api_server.rs
+++ b/dpd/src/api_server.rs
@@ -1149,7 +1149,7 @@ impl DpdApi for DpdApiImpl {
         let link_id = path.link_id;
         let entry = entry.into_inner();
         switch
-            .create_ipv4_address(port_id, link_id, entry)
+            .create_ipv4_address(port_id, link_id, entry.addr, entry.tag)
             .map(|_| HttpResponseUpdatedNoContent())
             .map_err(|e| e.into())
     }
@@ -1178,7 +1178,7 @@ impl DpdApi for DpdApiImpl {
         let link_id = path.link_id;
         let address = path.address;
         switch
-            .delete_ipv4_address(port_id, link_id, address)
+            .delete_ipv4_address(port_id, link_id, address, None)
             .map(|_| HttpResponseDeleted())
             .map_err(|e| e.into())
     }
@@ -1224,7 +1224,7 @@ impl DpdApi for DpdApiImpl {
         let link_id = path.link_id;
         let entry = entry.into_inner();
         switch
-            .create_ipv6_address(port_id, link_id, entry)
+            .create_ipv6_address(port_id, link_id, entry.addr, entry.tag)
             .map(|_| HttpResponseUpdatedNoContent())
             .map_err(|e| e.into())
     }
@@ -1253,7 +1253,7 @@ impl DpdApi for DpdApiImpl {
         let link_id = path.link_id;
         let address = path.address;
         switch
-            .delete_ipv6_address(port_id, link_id, address)
+            .delete_ipv6_address(port_id, link_id, address, None)
             .map(|_| HttpResponseDeleted())
             .map_err(|e| e.into())
     }
@@ -1842,9 +1842,10 @@ impl DpdApi for DpdApiImpl {
         let query = query.into_inner();
         let port_id = path.port_id;
         let settings = body.into_inner();
+        let tag = query.tag.as_deref().unwrap_or("");
 
         switch
-            .apply_port_settings(port_id, settings, query.tag)
+            .apply_port_settings(port_id, settings, tag)
             .await
             .map(HttpResponseOk)
             .map_err(HttpError::from)
@@ -1859,9 +1860,10 @@ impl DpdApi for DpdApiImpl {
         let path = path.into_inner();
         let query = query.into_inner();
         let port_id = path.port_id;
+        let tag = query.tag.as_deref().unwrap_or("");
 
         switch
-            .clear_port_settings(port_id, query.tag)
+            .clear_port_settings(port_id, tag)
             .await
             .map(HttpResponseOk)
             .map_err(HttpError::from)
@@ -1876,9 +1878,10 @@ impl DpdApi for DpdApiImpl {
         let path = path.into_inner();
         let query = query.into_inner();
         let port_id = path.port_id;
+        let tag = query.tag.as_deref().unwrap_or("");
 
         switch
-            .get_port_settings(port_id, query.tag)
+            .get_port_settings(port_id, tag)
             .await
             .map(HttpResponseOk)
             .map_err(HttpError::from)
@@ -2946,24 +2949,28 @@ pub(crate) fn build_info() -> BuildInfo {
     }
 }
 
-impl From<&crate::link::Link> for LinkSettings {
-    fn from(l: &crate::link::Link) -> Self {
-        let mut addrs: HashSet<IpAddr> = HashSet::new();
-        for a in &l.ipv4 {
-            addrs.insert(a.addr.into());
-        }
-        for a in &l.ipv6 {
-            addrs.insert(a.addr.into());
-        }
+impl crate::link::Link {
+    /// Creates a serializable [`LinkSettings`] representation with the
+    /// current link state and this tag's resources.
+    pub fn settings(&self, tag: &str) -> LinkSettings {
+        let addrs: HashSet<IpAddr> = self
+            .ipv4
+            .iter()
+            .map(|(&addr, t)| (IpAddr::from(addr), t))
+            .chain(self.ipv6.iter().map(|(&addr, t)| (addr.into(), t)))
+            .filter(|(_, t)| *t == tag)
+            .map(|(addr, _)| addr)
+            .collect();
+
         LinkSettings {
             params: LinkCreate {
-                lane: Some(l.link_id),
-                speed: l.config.speed,
-                fec: l.config.fec,
-                autoneg: l.config.autoneg,
-                kr: l.config.kr,
-                tx_eq: l.tx_eq,
-                allow_ddm_traffic: l.config.allow_ddm_traffic,
+                lane: Some(self.link_id),
+                speed: self.config.speed,
+                fec: self.config.fec,
+                autoneg: self.config.autoneg,
+                kr: self.config.kr,
+                tx_eq: self.tx_eq,
+                allow_ddm_traffic: self.config.allow_ddm_traffic,
             },
             addrs,
         }

--- a/dpd/src/link.rs
+++ b/dpd/src/link.rs
@@ -50,6 +50,7 @@ use slog::o;
 use slog::warn;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::btree_map;
 use std::collections::btree_map::Entry;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
@@ -236,10 +237,11 @@ pub struct Link {
     pub link_state: LinkState,
     /// The kind of media in the link.
     pub media: PortMedia,
-    /// A list of IPv4 addresses assigned to this link.
-    pub ipv4: BTreeSet<Ipv4Entry>,
-    /// A list of IPv6 addresses assigned to this link.
-    pub ipv6: BTreeSet<Ipv6Entry>,
+    /// IPv4 addresses assigned to this link.
+    /// Each is associated with its creator's ID tag.
+    pub ipv4: BTreeMap<Ipv4Addr, String>,
+    /// IPv6 addresses assigned to this link.
+    pub ipv6: BTreeMap<Ipv6Addr, String>,
     /// Tracks the history of linkup/linkdown transitions, allowing us to
     /// detect flapping links.
     pub linkup_tracker: LinkUpTracker,
@@ -475,8 +477,8 @@ impl Link {
             fsm_state: asic::PortFsmState::default(),
             link_state: LinkState::Unknown,
             media: PortMedia::None,
-            ipv4: BTreeSet::new(),
-            ipv6: BTreeSet::new(),
+            ipv4: BTreeMap::new(),
+            ipv6: BTreeMap::new(),
             linkup_tracker: LinkUpTracker::default(),
             autoneg_tracker: AutonegTracker::default(),
 
@@ -487,10 +489,7 @@ impl Link {
 
     /// Return the link-local address for this link, if one has been added.
     pub fn link_local(&self) -> Option<Ipv6Addr> {
-        self.ipv6
-            .iter()
-            .find(|entry| (entry.addr.segments()[0] & 0xffc0) == 0xfe80)
-            .map(|entry| entry.addr)
+        self.ipv6.keys().find(|addr| addr.is_unicast_link_local()).copied()
     }
 
     /// Return the FEC scheme in use for this link.  If the link has not yet
@@ -711,15 +710,11 @@ impl Switch {
 
         // Delete all addresses in the switch tables for this link.
         if !link.ipv4.is_empty() {
-            let to_delete = std::mem::take(&mut link.ipv4)
-                .into_iter()
-                .map(|entry| entry.addr);
+            let to_delete = std::mem::take(&mut link.ipv4).into_keys();
             port_ip::ipv4_delete_many(self, link.asic_port_id, to_delete)?;
         }
         if !link.ipv6.is_empty() {
-            let to_delete = std::mem::take(&mut link.ipv6)
-                .into_iter()
-                .map(|entry| entry.addr);
+            let to_delete = std::mem::take(&mut link.ipv6).into_keys();
             port_ip::ipv6_delete_many(self, link.asic_port_id, to_delete)?;
         }
 
@@ -741,15 +736,11 @@ impl Switch {
             // Swap out an empty map with the existing one, so that we can
             // retain an iterable for calling `ipv{4,6}_delete_many`.
             if !link.ipv4.is_empty() {
-                let to_delete = std::mem::take(&mut link.ipv4)
-                    .into_iter()
-                    .map(|entry| entry.addr);
+                let to_delete = std::mem::take(&mut link.ipv4).into_keys();
                 port_ip::ipv4_delete_many(self, link.asic_port_id, to_delete)?;
             }
             if !link.ipv6.is_empty() {
-                let to_delete = std::mem::take(&mut link.ipv6)
-                    .into_iter()
-                    .map(|entry| entry.addr);
+                let to_delete = std::mem::take(&mut link.ipv6).into_keys();
                 port_ip::ipv6_delete_many(self, link.asic_port_id, to_delete)?;
             }
         }
@@ -772,42 +763,26 @@ impl Switch {
     }
 
     fn clear_link_addresses_locked(&self, link: &mut Link, tag: &str) {
-        // Remove all entries from the set with the provided tag.
-        //
-        // TODO-cleanup: It'd be nice to use `drain_filter` here,
-        // but that is unstable.
-        let mut to_remove = Vec::new();
-        link.ipv4.retain(|entry| {
-            if entry.tag == tag {
-                to_remove.push(entry.addr);
-                false
-            } else {
-                true
-            }
-        });
-
         // Delete the entries from the ASIC tables.
         let _ = port_ip::ipv4_delete_many(
             self,
             link.asic_port_id,
-            to_remove.into_iter(),
+            link.ipv4
+                .iter()
+                .filter(|entry| entry.1 == tag)
+                .map(|entry| *entry.0),
         );
+        link.ipv4.retain(|_, t| t != tag);
 
-        // TODO-cleanup: See note above about `drain_filter`.
-        let mut to_remove = Vec::new();
-        link.ipv6.retain(|entry| {
-            if entry.tag == tag {
-                to_remove.push(entry.addr);
-                false
-            } else {
-                true
-            }
-        });
         let _ = port_ip::ipv6_delete_many(
             self,
             link.asic_port_id,
-            to_remove.into_iter(),
+            link.ipv6
+                .iter()
+                .filter(|entry| entry.1 == tag)
+                .map(|entry| *entry.0),
         );
+        link.ipv6.retain(|_, t| t != tag);
     }
 
     // Update the state of a link with a closure.
@@ -1047,17 +1022,19 @@ impl Switch {
     pub fn create_ipv4_address_locked(
         &self,
         link: &mut Link,
-        entry: Ipv4Entry,
+        addr: Ipv4Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        if link.ipv4.contains(&entry) {
-            Err(DpdError::Exists(format!(
-                "IP address {} already exists",
-                entry.addr
-            )))
-        } else {
-            port_ip::ipv4_add(self, link.asic_port_id, entry.addr)?;
-            link.ipv4.insert(entry);
-            Ok(())
+        match link.ipv4.entry(addr) {
+            btree_map::Entry::Occupied(curr) => Err(DpdError::Exists(format!(
+                "IP address {addr} already exists under tag {}",
+                curr.get()
+            ))),
+            btree_map::Entry::Vacant(slot) => {
+                port_ip::ipv4_add(self, link.asic_port_id, addr)?;
+                slot.insert(tag);
+                Ok(())
+            }
         }
     }
 
@@ -1066,10 +1043,11 @@ impl Switch {
         &self,
         port_id: PortId,
         link_id: LinkId,
-        entry: Ipv4Entry,
+        addr: Ipv4Addr,
+        tag: String,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            self.create_ipv4_address_locked(link, entry)
+            self.create_ipv4_address_locked(link, addr, tag)
         })
     }
 
@@ -1082,40 +1060,52 @@ impl Switch {
         limit: usize,
     ) -> DpdResult<Vec<Ipv4Entry>> {
         self.link_fetch(port_id, link_id, |link| {
-            if let Some(addr) = last_address {
-                // Equality only considers the address, so create an entry
-                // with an empty tag.
-                use std::ops::Bound;
-                let entry = Ipv4Entry { tag: String::new(), addr };
-                link.ipv4
-                    .range((Bound::Excluded(entry), Bound::Unbounded))
-                    .take(limit)
-                    .cloned()
-                    .collect()
+            let bounds = if let Some(addr) = last_address {
+                (std::ops::Bound::Excluded(addr), std::ops::Bound::Unbounded)
             } else {
-                link.ipv4.iter().take(limit).cloned().collect()
-            }
+                (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+            };
+
+            link.ipv4
+                .range(bounds)
+                .take(limit)
+                .map(|(&addr, tag)| Ipv4Entry { addr, tag: tag.clone() })
+                .collect()
         })
     }
 
-    /// Delete one IPv4 address on the provided link.
+    /// Deletes this IPv4 address from the link.
+    ///
+    /// Returns Err if the address is not found.
+    ///
+    /// If tag is None, the address is deleted regardless of tag.
+    /// If tag is Some, the address is only deleted if its registration
+    /// tag matches the given tag.
     pub fn delete_ipv4_address_locked(
         &self,
         link: &mut Link,
-        address: Ipv4Addr,
+        addr: Ipv4Addr,
+        tag: Option<&str>,
     ) -> DpdResult<()> {
-        let entry = Ipv4Entry { tag: String::new(), addr: address };
-
-        if link.ipv4.contains(&entry) {
-            port_ip::ipv4_delete(self, link.asic_port_id, address)?;
-            link.ipv4.remove(&entry);
-            Ok(())
-        } else {
-            Err(DpdError::NoSuchAddress {
+        match link.ipv4.entry(addr) {
+            btree_map::Entry::Vacant(_) => Err(DpdError::NoSuchAddress {
                 port_id: link.port_id,
                 link_id: link.link_id,
-                address: address.into(),
-            })
+                address: addr.into(),
+            }),
+            btree_map::Entry::Occupied(slot)
+                if tag.is_some_and(|t| t != slot.get()) =>
+            {
+                Err(DpdError::AddrTagConflict {
+                    addr: addr.into(),
+                    tag: slot.get().to_string(),
+                })
+            }
+            btree_map::Entry::Occupied(slot) => {
+                port_ip::ipv4_delete(self, link.asic_port_id, addr)?;
+                slot.remove();
+                Ok(())
+            }
         }
     }
 
@@ -1124,10 +1114,11 @@ impl Switch {
         &self,
         port_id: PortId,
         link_id: LinkId,
-        address: Ipv4Addr,
+        addr: Ipv4Addr,
+        tag: Option<&str>,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            self.delete_ipv4_address_locked(link, address)
+            self.delete_ipv4_address_locked(link, addr, tag)
         })
     }
 
@@ -1138,8 +1129,9 @@ impl Switch {
         link_id: LinkId,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            while let Some(Ipv4Entry { addr, .. }) = link.ipv4.pop_first() {
-                port_ip::ipv4_delete(self, link.asic_port_id, addr)?;
+            while let Some(entry) = link.ipv4.first_entry() {
+                port_ip::ipv4_delete(self, link.asic_port_id, *entry.key())?;
+                entry.remove();
             }
             Ok(())
         })
@@ -1149,17 +1141,19 @@ impl Switch {
     pub fn create_ipv6_address_locked(
         &self,
         link: &mut Link,
-        entry: Ipv6Entry,
+        addr: Ipv6Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        if link.ipv6.contains(&entry) {
-            Err(DpdError::Exists(format!(
-                "IP address {} already exists",
-                entry.addr
-            )))
-        } else {
-            port_ip::ipv6_add(self, link.asic_port_id, entry.addr)?;
-            link.ipv6.insert(entry);
-            Ok(())
+        match link.ipv6.entry(addr) {
+            btree_map::Entry::Occupied(curr) => Err(DpdError::Exists(format!(
+                "IP address {addr} already exists under tag {}",
+                curr.get()
+            ))),
+            btree_map::Entry::Vacant(slot) => {
+                port_ip::ipv6_add(self, link.asic_port_id, addr)?;
+                slot.insert(tag);
+                Ok(())
+            }
         }
     }
 
@@ -1168,10 +1162,11 @@ impl Switch {
         &self,
         port_id: PortId,
         link_id: LinkId,
-        entry: Ipv6Entry,
+        addr: Ipv6Addr,
+        tag: String,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            self.create_ipv6_address_locked(link, entry)
+            self.create_ipv6_address_locked(link, addr, tag)
         })
     }
 
@@ -1184,40 +1179,52 @@ impl Switch {
         limit: usize,
     ) -> DpdResult<Vec<Ipv6Entry>> {
         self.link_fetch(port_id, link_id, |link| {
-            if let Some(addr) = last_address {
-                // Equality only considers the address, so create an entry
-                // with an empty tag.
-                use std::ops::Bound;
-                let entry = Ipv6Entry { tag: String::new(), addr };
-                link.ipv6
-                    .range((Bound::Excluded(entry), Bound::Unbounded))
-                    .take(limit)
-                    .cloned()
-                    .collect()
+            let bounds = if let Some(addr) = last_address {
+                (std::ops::Bound::Excluded(addr), std::ops::Bound::Unbounded)
             } else {
-                link.ipv6.iter().take(limit).cloned().collect()
-            }
+                (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+            };
+
+            link.ipv6
+                .range(bounds)
+                .take(limit)
+                .map(|(&addr, tag)| Ipv6Entry { addr, tag: tag.clone() })
+                .collect()
         })
     }
 
-    /// Delete one IPv6 address on the provided link.
+    /// Deletes this IPv6 address from the link.
+    ///
+    /// Returns Err if the address is not found.
+    ///
+    /// If tag is None, the address is deleted regardless of tag.
+    /// If tag is Some, the address is only deleted if its registration
+    /// tag matches the given tag.
     pub fn delete_ipv6_address_locked(
         &self,
         link: &mut Link,
         address: Ipv6Addr,
+        tag: Option<&str>,
     ) -> DpdResult<()> {
-        let entry = Ipv6Entry { tag: String::new(), addr: address };
-
-        if link.ipv6.contains(&entry) {
-            port_ip::ipv6_delete(self, link.asic_port_id, address)?;
-            link.ipv6.remove(&entry);
-            Ok(())
-        } else {
-            Err(DpdError::NoSuchAddress {
+        match link.ipv6.entry(address) {
+            btree_map::Entry::Vacant(_) => Err(DpdError::NoSuchAddress {
                 port_id: link.port_id,
                 link_id: link.link_id,
                 address: address.into(),
-            })
+            }),
+            btree_map::Entry::Occupied(slot)
+                if tag.is_some_and(|t| t != slot.get()) =>
+            {
+                Err(DpdError::AddrTagConflict {
+                    addr: address.into(),
+                    tag: slot.get().to_string(),
+                })
+            }
+            btree_map::Entry::Occupied(slot) => {
+                port_ip::ipv6_delete(self, link.asic_port_id, address)?;
+                slot.remove();
+                Ok(())
+            }
         }
     }
 
@@ -1227,9 +1234,10 @@ impl Switch {
         port_id: PortId,
         link_id: LinkId,
         address: Ipv6Addr,
+        tag: Option<&str>,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            self.delete_ipv6_address_locked(link, address)
+            self.delete_ipv6_address_locked(link, address, tag)
         })
     }
 
@@ -1240,8 +1248,9 @@ impl Switch {
         link_id: LinkId,
     ) -> DpdResult<()> {
         self.link_update(port_id, link_id, |link| {
-            while let Some(Ipv6Entry { addr, .. }) = link.ipv6.pop_first() {
-                port_ip::ipv6_delete(self, link.asic_port_id, addr)?;
+            while let Some(entry) = link.ipv6.first_entry() {
+                port_ip::ipv6_delete(self, link.asic_port_id, *entry.key())?;
+                entry.remove();
             }
             Ok(())
         })

--- a/dpd/src/port_settings.rs
+++ b/dpd/src/port_settings.rs
@@ -10,8 +10,6 @@ use crate::Switch;
 use crate::link::Link;
 use crate::link::LinkParams;
 use aal::AsicOps;
-use common::ports::Ipv4Entry;
-use common::ports::Ipv6Entry;
 use common::ports::PortFec;
 use common::ports::PortId;
 use common::ports::PortSpeed;
@@ -23,6 +21,7 @@ use slog::Logger;
 use slog::debug;
 use slog::error;
 use slog::trace;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -99,8 +98,9 @@ struct LinkSpec {
     pub autoneg: bool,
     pub kr: bool,
     pub delete_me: bool,
-    pub ipv4: BTreeSet<Ipv4Addr>,
-    pub ipv6: BTreeSet<Ipv6Addr>,
+    // (address, owner tag)
+    pub ipv4: BTreeMap<Ipv4Addr, String>,
+    pub ipv6: BTreeMap<Ipv6Addr, String>,
     pub tx_eq: Option<TxEq>,
     pub allow_ddm_traffic: bool,
 }
@@ -114,40 +114,79 @@ impl From<&Link> for LinkSpec {
             kr: p.config.kr,
             tx_eq: p.tx_eq,
             delete_me: p.config.delete_me,
-            ipv4: p.ipv4.iter().map(|x| x.addr).collect(),
-            ipv6: p.ipv6.iter().map(|x| x.addr).collect(),
+            ipv4: p.ipv4.clone(),
+            ipv6: p.ipv6.clone(),
             allow_ddm_traffic: p.config.allow_ddm_traffic,
         }
     }
 }
 
-impl From<&LinkSettings> for LinkSpec {
-    fn from(l: &LinkSettings) -> Self {
-        Self {
+impl LinkSpec {
+    /// Constructs a [`LinkSpec`] based on the given [`LinkSettings`].
+    ///
+    /// If `current` is Some, the resulting LinkSpec includes addresses
+    /// from [`LinkSettings`] and those of all *other* tags in `current`.
+    ///
+    /// Returns error if an address in [`LinkSettings`] is already
+    /// owned in `current` by another tag.
+    pub fn try_from_settings(
+        l: &LinkSettings,
+        tag: &str,
+        current: Option<&LinkSpec>,
+    ) -> DpdResult<Self> {
+        let mut ipv4 = BTreeMap::new();
+        let mut ipv6 = BTreeMap::new();
+
+        if let Some(current) = current {
+            ipv4.extend(
+                current
+                    .ipv4
+                    .iter()
+                    .filter(|(_, entry_tag)| entry_tag.as_str() != tag)
+                    .map(|(addr, entry_tag)| (*addr, entry_tag.to_string())),
+            );
+
+            ipv6.extend(
+                current
+                    .ipv6
+                    .iter()
+                    .filter(|(_, entry_tag)| entry_tag.as_str() != tag)
+                    .map(|(addr, entry_tag)| (*addr, entry_tag.to_string())),
+            );
+        }
+
+        for addr in &l.addrs {
+            match addr {
+                IpAddr::V4(v4) => {
+                    if let Some(owner) = ipv4.insert(*v4, tag.to_string()) {
+                        return Err(DpdError::AddrTagConflict {
+                            addr: *addr,
+                            tag: owner,
+                        });
+                    }
+                }
+                IpAddr::V6(v6) => {
+                    if let Some(owner) = ipv6.insert(*v6, tag.to_string()) {
+                        return Err(DpdError::AddrTagConflict {
+                            addr: *addr,
+                            tag: owner,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
             speed: l.params.speed,
             fec: l.params.fec,
             autoneg: l.params.autoneg,
             kr: l.params.kr,
             tx_eq: l.params.tx_eq,
             delete_me: false,
-            ipv4: l
-                .addrs
-                .iter()
-                .filter_map(
-                    |x| if let IpAddr::V4(a) = x { Some(a) } else { None },
-                )
-                .copied()
-                .collect(),
-            ipv6: l
-                .addrs
-                .iter()
-                .filter_map(
-                    |x| if let IpAddr::V6(a) = x { Some(a) } else { None },
-                )
-                .copied()
-                .collect(),
+            ipv4,
+            ipv6,
             allow_ddm_traffic: l.params.allow_ddm_traffic,
-        }
+        })
     }
 }
 
@@ -187,6 +226,11 @@ impl PortSettingsDiff {
         // Collect all the links that exist on the port.
         let switch_links = ctx.link_map.port_links(ctx.port_id);
 
+        // dendrite/342: Tags only protect address modifications.
+        // This endpoint allows one client to subtly delete a link
+        // created by another client regardless of tag. But this
+        // concern is not exercised under current usage.
+
         // Determine what we need to add/delete/modify
         let links_to_add = settings_links.difference(&switch_links);
         let links_to_del = switch_links.difference(&settings_links);
@@ -194,9 +238,11 @@ impl PortSettingsDiff {
 
         self.links.add = links_to_add
             .map(|id| {
-                (*id, ChangeNode::Unchanged((&settings.links[&id.0]).into()))
+                let conf = &settings.links[&id.0];
+                let spec = LinkSpec::try_from_settings(conf, ctx.tag, None)?;
+                Ok((*id, ChangeNode::Unchanged(spec)))
             })
-            .collect();
+            .collect::<DpdResult<_>>()?;
 
         self.links.delete = links_to_del
             .map(|id| {
@@ -210,24 +256,28 @@ impl PortSettingsDiff {
             .collect();
 
         self.links.modify = links_to_mod
-            .map(|id| {
-                let settings_link = (&settings.links[&id.0]).into();
-                let switch_link = ctx.link_spec(*id).expect(
+            .filter_map(|id| {
+                let before = ctx.link_spec(*id).expect(
                     "link existence is guaranteed by the locked link map",
                 );
-                (id, settings_link, switch_link)
+
+                let maybe_after = LinkSpec::try_from_settings(
+                    &settings.links[&id.0],
+                    ctx.tag,
+                    Some(&before),
+                );
+                let after = match maybe_after {
+                    Ok(spec) => spec,
+                    Err(e) => return Some(Err(e)),
+                };
+
+                if before == after {
+                    return None;
+                }
+
+                Some(Ok((*id, ChangeNode::Unchanged(Modify { before, after }))))
             })
-            .filter(|(_, settings, switch)| settings != switch)
-            .map(|(id, settings, switch)| {
-                (
-                    *id,
-                    ChangeNode::Unchanged(Modify {
-                        before: switch,
-                        after: settings,
-                    }),
-                )
-            })
-            .collect();
+            .collect::<DpdResult<_>>()?;
 
         Ok(())
     }
@@ -351,13 +401,13 @@ impl PortSettingsDiff {
         });
 
         // Create the IPv4 addresses
-        for addr in spec.ipv4.iter().copied() {
-            Self::addr_add_v4(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in &spec.ipv4 {
+            Self::addr_add_v4(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
         // Create the IPv6 addresses
-        for addr in spec.ipv6.iter().copied() {
-            Self::addr_add_v6(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in &spec.ipv6 {
+            Self::addr_add_v6(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
         Ok(())
@@ -382,13 +432,13 @@ impl PortSettingsDiff {
         });
 
         // Delete the IPv4 addresses
-        for addr in spec.ipv4.iter().copied() {
-            Self::addr_del_v4(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in &spec.ipv4 {
+            Self::addr_del_v4(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
         // Delete the IPv6 addresses
-        for addr in spec.ipv6.iter().copied() {
-            Self::addr_del_v6(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in &spec.ipv6 {
+            Self::addr_del_v6(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
         Ok(())
@@ -472,32 +522,34 @@ impl PortSettingsDiff {
             Ok(())
         });
 
-        // ipv4 addrs
-        let v4_add: BTreeSet<Ipv4Addr> =
-            ipv4_after.difference(ipv4_before).copied().collect();
+        let v4_add = ipv4_after
+            .iter()
+            .filter(|(addr, _)| !ipv4_before.contains_key(addr));
+        let v4_del = ipv4_before
+            .iter()
+            .filter(|(addr, _)| !ipv4_after.contains_key(addr));
 
-        let v4_del: BTreeSet<Ipv4Addr> =
-            ipv4_before.difference(ipv4_after).copied().collect();
-
-        for addr in v4_add {
-            Self::addr_add_v4(ctx, &mut link, rb, addr)?;
-        }
-        for addr in v4_del {
-            Self::addr_del_v4(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in v4_add {
+            Self::addr_add_v4(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
-        // ipv6 addrs
-        let v6_add: BTreeSet<Ipv6Addr> =
-            ipv6_after.difference(ipv6_before).copied().collect();
-
-        let v6_del: BTreeSet<Ipv6Addr> =
-            ipv6_before.difference(ipv6_after).copied().collect();
-
-        for addr in v6_add {
-            Self::addr_add_v6(ctx, &mut link, rb, addr)?;
+        for (addr, tag) in v4_del {
+            Self::addr_del_v4(ctx, &mut link, rb, *addr, tag.clone())?;
         }
-        for addr in v6_del {
-            Self::addr_del_v6(ctx, &mut link, rb, addr)?;
+
+        let v6_add = ipv6_after
+            .iter()
+            .filter(|(addr, _)| !ipv6_before.contains_key(addr));
+        let v6_del = ipv6_before
+            .iter()
+            .filter(|(addr, _)| !ipv6_after.contains_key(addr));
+
+        for (addr, tag) in v6_add {
+            Self::addr_add_v6(ctx, &mut link, rb, *addr, tag.clone())?;
+        }
+
+        for (addr, tag) in v6_del {
+            Self::addr_del_v6(ctx, &mut link, rb, *addr, tag.clone())?;
         }
 
         Ok(())
@@ -508,20 +560,19 @@ impl PortSettingsDiff {
         link: &mut Link,
         rb: &mut Rollback,
         addr: Ipv4Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        trace!(ctx.log, "ipv4 add {addr}");
+        trace!(ctx.log, "ipv4 add ({addr}: {tag})");
         // Create address on ASIC first.
-        let entry =
-            Ipv4Entry { tag: ctx.tag.clone().unwrap_or("".into()), addr };
         let switch = ctx.switch;
-        switch.create_ipv4_address_locked(link, entry)?;
+        switch.create_ipv4_address_locked(link, addr, tag.clone())?;
 
         let link_id = link.link_id;
         rb.wind(move |ctx: &mut Context<'_>| -> DpdResult<()> {
             let switch = ctx.switch;
             let link_lock = ctx.link(link_id)?;
             let mut link = link_lock.lock().unwrap();
-            switch.delete_ipv4_address_locked(&mut link, addr)
+            switch.delete_ipv4_address_locked(&mut link, addr, Some(&tag))
         });
         Ok(())
     }
@@ -531,19 +582,18 @@ impl PortSettingsDiff {
         link: &mut Link,
         rb: &mut Rollback,
         addr: Ipv4Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        trace!(ctx.log, "ipv4 del {addr}");
-        let entry =
-            Ipv4Entry { tag: ctx.tag.clone().unwrap_or("".into()), addr };
+        trace!(ctx.log, "ipv4 del ({addr}: {tag})");
         let switch = ctx.switch;
         let link_id = link.link_id;
-        switch.delete_ipv4_address_locked(link, addr)?;
+        switch.delete_ipv4_address_locked(link, addr, Some(&tag))?;
 
         rb.wind(move |ctx: &mut Context<'_>| -> DpdResult<()> {
             let switch = ctx.switch;
             let link_lock = ctx.link(link_id)?;
             let mut link = link_lock.lock().unwrap();
-            switch.create_ipv4_address_locked(&mut link, entry)
+            switch.create_ipv4_address_locked(&mut link, addr, tag)
         });
         Ok(())
     }
@@ -553,20 +603,19 @@ impl PortSettingsDiff {
         link: &mut Link,
         rb: &mut Rollback,
         addr: Ipv6Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        trace!(ctx.log, "ipv6 add {addr}");
+        trace!(ctx.log, "ipv6 add ({addr}: {tag})");
         // Create address on ASIC first.
-        let entry =
-            Ipv6Entry { tag: ctx.tag.clone().unwrap_or("".into()), addr };
         let switch = ctx.switch;
         let link_id = link.link_id;
-        switch.create_ipv6_address_locked(link, entry)?;
+        switch.create_ipv6_address_locked(link, addr, tag.clone())?;
 
         rb.wind(move |ctx: &mut Context<'_>| -> DpdResult<()> {
             let switch = ctx.switch;
             let link_lock = ctx.link(link_id)?;
             let mut link = link_lock.lock().unwrap();
-            switch.delete_ipv6_address_locked(&mut link, addr)
+            switch.delete_ipv6_address_locked(&mut link, addr, Some(&tag))
         });
         Ok(())
     }
@@ -576,19 +625,18 @@ impl PortSettingsDiff {
         link: &mut Link,
         rb: &mut Rollback,
         addr: Ipv6Addr,
+        tag: String,
     ) -> DpdResult<()> {
-        trace!(ctx.log, "ipv6 del {addr}");
+        trace!(ctx.log, "ipv6 del ({addr}: {tag})");
         let switch = ctx.switch;
         let link_id = link.link_id;
-        switch.delete_ipv6_address_locked(link, addr)?;
+        switch.delete_ipv6_address_locked(link, addr, Some(&tag))?;
 
         rb.wind(move |ctx: &mut Context<'_>| -> DpdResult<()> {
-            let entry =
-                Ipv6Entry { tag: ctx.tag.clone().unwrap_or("".into()), addr };
             let switch = ctx.switch;
             let link_lock = ctx.link(link_id)?;
             let mut link = link_lock.lock().unwrap();
-            switch.create_ipv6_address_locked(&mut link, entry)
+            switch.create_ipv6_address_locked(&mut link, addr, tag)
         });
         Ok(())
     }
@@ -628,18 +676,18 @@ struct Context<'a> {
     port_id: PortId,
     switch: &'a Switch,
     link_map: MutexGuard<'a, crate::link::LinkMap>,
-    tag: Option<String>,
+    tag: &'a str,
     log: Logger,
     rollback: bool,
 }
 
 macro_rules! context {
-    ($port_id:expr, $switch:expr) => {
+    ($port_id:expr, $switch:expr, $tag:expr) => {
         Context {
             port_id: $port_id,
             switch: $switch,
             link_map: $switch.links.lock().unwrap(),
-            tag: None,
+            tag: $tag,
             log: $switch.log.clone(),
             rollback: false,
         }
@@ -664,10 +712,9 @@ impl Switch {
         &self,
         port_id: PortId,
         settings: PortSettings,
-        tag: Option<String>,
+        tag: &str,
     ) -> DpdResult<PortSettings> {
-        let mut ctx = context!(port_id, self);
-        ctx.tag = tag;
+        let mut ctx = context!(port_id, self, tag);
 
         let mut diff = PortSettingsDiff::calculate(&mut ctx, &settings)?;
         trace!(self.log, "port settings diff: {:#?}", diff);
@@ -680,10 +727,9 @@ impl Switch {
     pub async fn clear_port_settings(
         &self,
         port_id: PortId,
-        tag: Option<String>,
+        tag: &str,
     ) -> DpdResult<PortSettings> {
-        let mut ctx = context!(port_id, self);
-        ctx.tag = tag;
+        let mut ctx = context!(port_id, self, tag);
 
         let settings = PortSettings::default();
         let mut diff = PortSettingsDiff::calculate(&mut ctx, &settings)?;
@@ -697,10 +743,9 @@ impl Switch {
     pub async fn get_port_settings(
         &self,
         port_id: PortId,
-        tag: Option<String>,
+        tag: &str,
     ) -> DpdResult<PortSettings> {
-        let mut ctx = context!(port_id, self);
-        ctx.tag = tag;
+        let mut ctx = context!(port_id, self, tag);
         Self::get_port_settings_locked(&mut ctx, false)
     }
 
@@ -737,7 +782,7 @@ impl Switch {
                     if ignore_deleting && link.config.delete_me {
                         None
                     } else {
-                        Some(((*link_id).into(), LinkSettings::from(&*link)))
+                        Some(((*link_id).into(), link.settings(ctx.tag)))
                     }
                 } else {
                     None

--- a/dpd/src/types.rs
+++ b/dpd/src/types.rs
@@ -88,6 +88,8 @@ pub enum DpdError {
     ResourceExhausted(String),
     #[error("Tag is required for idempotent validation")]
     MissingTag,
+    #[error("Address {addr} exists, but it is owned by another tag: {tag}")]
+    AddrTagConflict { addr: IpAddr, tag: String },
 }
 
 impl From<smf::ScfError> for DpdError {
@@ -287,6 +289,13 @@ impl convert::From<DpdError> for dropshot::HttpError {
             e @ DpdError::MissingTag => {
                 dropshot::HttpError::for_bad_request(None, format!("{e}"))
             }
+            e @ DpdError::AddrTagConflict { .. } => dropshot::HttpError {
+                status_code: dropshot::ErrorStatusCode::CONFLICT,
+                error_code: None,
+                internal_message: e.to_string(),
+                external_message: e.to_string(),
+                headers: None,
+            },
         }
     }
 }


### PR DESCRIPTION
Reproduces and fixes https://github.com/oxidecomputer/dendrite/issues/342
See that issue if you have questions about this design.

### Tests

These tests failed before the second commit.

```txt
failures:
    chaos_tests::port_settings::address_cmds_respect_tags
    chaos_tests::port_settings::apply_fails_on_tag_conflict
    chaos_tests::port_settings::settings_apply_respects_tags
    chaos_tests::port_settings::settings_clear_ignores_tags
```

- `settings_apply_respects_tags` is the most important. It exercises the basic enforcement of tag separation. One tag creates an address. Another tag applies an address. The first tag's address still needs to exist. This is the motivating issue between tfportd and sled-agent. This test fails when tag1 lists addresses and sees that its address is missing.
- `address_cmds_respect_tags` verifies tags are respected by address commands of the type used in swadm, tfportd, and maghemite. CRUD itself works, but the test fails in verification when `port_settings_get` returns more addresses than `link_ipv*_list`.
- `apply_fails_on_tag_conflict` is a weird but meaningful edge case. The passing test `create_addr_rejects_overwrites` demonstrates that creating an address fails if the address already exists (under another tag). `port_settings_apply` should allow re-declaring addresses of the same tag, but it should fail when creating an address that belongs to a different tag rather than stealing the address from that tag. Stealing the address complicates deletion, which is implicated if a transaction ever needs to be rolled back. This particular test fails on "Addresses belong to another tag" because stealing is allowed in the current implementation.
- `settings_clear_ignores_tags` exercises the same issue as `settings_apply_respects_tags`. If I remove the `tag1` check, then this passes. So it's more collateral damage than a legit failure. After all, the test is meant to describe the current behavior rather than declare what it should be.

### Summary

The main change is in `port_settings.rs`, where we merge addresses belonging to other tags into the diffable representation.

### Context

This PR makes a decision about address tagging in DPD, and it tries to avoid other structural changes. This in-progress stacked PR is exploring solutions for txn test failures and ip addr code simplification: https://github.com/oxidecomputer/dendrite/pull/374

### Decisions

- Tagged addresses are stored in a `BTreeMap<Ipv*Addr, String>`. So an address may necessarily only be added to a link by a single tag. I believe this was the previous behavior too, but it's more self-enforcing than `BTreeSet<Ipv*Entry>`. I would like a more descriptive `Tag` type, but that implies a lot of API changes and felt out of scope for this PR. Right now we're just trying to make the current API work as expected.
- Currently addresses are the only tagged resource on a link.
- If a resource is tagged, it is unconditionally tagged. This was already the case in the `Link` struct, but that invariant was a bit hidden. Where the dropshot api uses `Option<String>` as a tag, we unwrap that to `""` in `api_server.rs`. We were already doing this in most/all places, but now it's more visible at the top layer.
- `LinkSpec` holds addresses for all tags, which is necessary to avoid dropping other tags during `port_settings_apply`. This contrasts with `LinkSettings`, which only reflects addresses from a single tag.

# Validation

This PR warrants system-level testing. I'm currently setting up an eval env, and I intend to post a voxel smoke test soon.
