### PR TITLE
Claude repro for txn test failures

### DIFF
--- a/dpd/src/link.rs
+++ b/dpd/src/link.rs
@@ -21,6 +21,7 @@ use crate::table::uplink;
 use crate::transceivers::qsfp_xcvr_mpn;
 use crate::types::DpdError;
 use crate::types::DpdResult;
+use aal::AsicError;
 use aal::AsicId;
 use aal::AsicOps;
 use aal::AsicResult;
@@ -1622,28 +1623,66 @@ pub async fn init_update_handler(switch: &Arc<Switch>) -> AsicResult<()> {
     Ok(())
 }
 
+// A table entry we were asked to remove is already gone, so the state we want
+// is the state we have.  This is the expected result when the reconciler
+// retries a teardown that previously failed partway through.
+fn ignore_missing(r: DpdResult<()>) -> DpdResult<()> {
+    match r {
+        Err(DpdError::Switch(AsicError::Missing(_))) => Ok(()),
+        r => r,
+    }
+}
+
+// Program all of the table entries that map a link to its MAC address.
+//
+// Each of these steps is tracked by the single `plumbed.mac` field, which is
+// only updated once all of them have succeeded.  The reconciler will therefore
+// call this again after a partial failure, and every step has to converge on
+// the requested state rather than fail on an entry it installed itself.  An
+// `Exists` error means the entry is present but may hold stale contents, so we
+// rewrite it.
 fn set_mac_config(
     switch: &Switch,
     asic_id: AsicId,
     mac: MacAddr,
 ) -> DpdResult<()> {
-    mac::mac_set(switch, asic_id, mac)?;
+    match mac::mac_set(switch, asic_id, mac) {
+        Err(DpdError::Switch(AsicError::Exists)) => {
+            mac::mac_update(switch, asic_id, mac)
+        }
+        r => r,
+    }?;
 
     #[cfg(feature = "multicast")]
     {
-        mac::mcast_mac_set(switch, asic_id, mac)?;
-        mcast::mcast_egress::add_port_mapping_entry(switch, asic_id)?;
+        match mac::mcast_mac_set(switch, asic_id, mac) {
+            Err(DpdError::Switch(AsicError::Exists)) => {
+                mac::mcast_mac_update(switch, asic_id, mac)
+            }
+            r => r,
+        }?;
+        match mcast::mcast_egress::add_port_mapping_entry(switch, asic_id) {
+            Err(DpdError::Switch(AsicError::Exists)) => {
+                mcast::mcast_egress::update_port_mapping_entry(switch, asic_id)
+            }
+            r => r,
+        }?;
     }
     Ok(())
 }
 
+// Remove the table entries programmed by `set_mac_config()`.  As above, the
+// reconciler may be retrying after a partial failure, so an entry that is
+// already gone is not an error.
 fn clear_mac_config(switch: &Switch, asic_id: AsicId) -> DpdResult<()> {
-    mac::mac_clear(switch, asic_id)?;
+    ignore_missing(mac::mac_clear(switch, asic_id))?;
 
     #[cfg(feature = "multicast")]
     {
-        mac::mcast_mac_clear(switch, asic_id)?;
-        mcast::mcast_egress::del_port_mapping_entry(switch, asic_id)?;
+        ignore_missing(mac::mcast_mac_clear(switch, asic_id))?;
+        ignore_missing(mcast::mcast_egress::del_port_mapping_entry(
+            switch, asic_id,
+        ))?;
     }
     Ok(())
 }

--- a/dpd/src/table/mac.rs
+++ b/dpd/src/table/mac.rs
@@ -52,6 +52,30 @@ fn mac_set_common(
     }
 }
 
+fn mac_update_common(
+    s: &Switch,
+    type_: TableType,
+    port: u16,
+    mac: MacAddr,
+) -> DpdResult<()> {
+    let match_key = MacMatchKey { port };
+    let action_data = MacAction::Rewrite { mac };
+
+    match s.table_entry_update(type_, &match_key, &action_data) {
+        Ok(_) => {
+            info!(s.log, "updated mac on {port} in table {type_}: {mac}",);
+            Ok(())
+        }
+        Err(e) => {
+            error!(
+                s.log,
+                "update mac on {port} in table {type_}: {mac} failed: {e:?}",
+            );
+            Err(e)
+        }
+    }
+}
+
 fn mac_clear_common(s: &Switch, type_: TableType, port: u16) -> DpdResult<()> {
     let match_key = MacMatchKey { port };
 
@@ -72,6 +96,14 @@ fn mac_clear_common(s: &Switch, type_: TableType, port: u16) -> DpdResult<()> {
 /// An error is returned if the entry already exists. Use `mac_update` instead.
 pub fn mac_set(s: &Switch, port: u16, mac: MacAddr) -> DpdResult<()> {
     mac_set_common(s, TableType::PortMacAddress, port, mac)
+}
+
+/// Rewrite an existing entry in the MAC table.
+///
+/// An error is returned if the entry does not already exist.  Use `mac_set`
+/// instead.
+pub fn mac_update(s: &Switch, port: u16, mac: MacAddr) -> DpdResult<()> {
+    mac_update_common(s, TableType::PortMacAddress, port, mac)
 }
 
 /// Remove an entry from the MAC table.
@@ -105,6 +137,15 @@ pub fn reset(s: &Switch) -> DpdResult<()> {
 #[cfg(feature = "multicast")]
 pub fn mcast_mac_set(s: &Switch, port: u16, mac: MacAddr) -> DpdResult<()> {
     mac_set_common(s, TableType::PortMacAddressMcast, port, mac)
+}
+
+/// Rewrite an existing entry in the multicast MAC table.
+///
+/// An error is returned if the entry does not already exist.  Use
+/// `mcast_mac_set` instead.
+#[cfg(feature = "multicast")]
+pub fn mcast_mac_update(s: &Switch, port: u16, mac: MacAddr) -> DpdResult<()> {
+    mac_update_common(s, TableType::PortMacAddressMcast, port, mac)
 }
 
 /// Remove an entry from the MAC table.

--- a/dpd/src/table/mcast/mcast_egress.rs
+++ b/dpd/src/table/mcast/mcast_egress.rs
@@ -209,7 +209,6 @@ pub(crate) fn add_port_mapping_entry(
 
 /// Update a port ID entry in the port ID table for converting ASIC port IDs
 /// to port numbers.
-#[allow(dead_code)]
 pub(crate) fn update_port_mapping_entry(
     s: &Switch,
     asic_port_id: u16,

--- a/dpd/src/table/uplink.rs
+++ b/dpd/src/table/uplink.rs
@@ -11,7 +11,7 @@ use slog::{error, info};
 
 use crate::Switch;
 use crate::table::*;
-use aal::{ActionParse, MatchParse};
+use aal::{ActionParse, AsicError, MatchParse};
 use aal_macros::*;
 
 #[derive(MatchParse, Debug, Hash)]
@@ -38,13 +38,19 @@ enum EgressAction {
     Allowed,
 }
 
+// Both of these tables carry a single, argument-free action, so an entry that
+// is already present is already correct.  `uplink_set()` and `uplink_clear()`
+// are driven by the link reconciler, which retries them after a failure -
+// including a failure that left one of the two tables already converged - so
+// they have to treat "the entry is how I want it" as success rather than as an
+// error.
 fn set_ingress_uplink(s: &Switch, port: u16) -> DpdResult<()> {
     let match_key = IngressMatchKey { in_port: port };
     let action_data = IngressAction::UplinkPort;
 
     match s.table_entry_add(TableType::UplinkIngress, &match_key, &action_data)
     {
-        Ok(_) => {
+        Ok(_) | Err(DpdError::Switch(AsicError::Exists)) => {
             info!(s.log, "set uplink on {}", port);
             Ok(())
         }
@@ -59,7 +65,7 @@ fn clear_ingress_uplink(s: &Switch, port: u16) -> DpdResult<()> {
     let match_key = IngressMatchKey { in_port: port };
 
     match s.table_entry_del(TableType::UplinkIngress, &match_key) {
-        Ok(_) => {
+        Ok(_) | Err(DpdError::Switch(AsicError::Missing(_))) => {
             info!(s.log, "cleared uplink on {}", port);
             Ok(())
         }
@@ -78,7 +84,7 @@ pub fn uplink_set(s: &Switch, port: u16) -> DpdResult<()> {
     let action_data = EgressAction::Allowed;
 
     match s.table_entry_add(TableType::UplinkEgress, &match_key, &action_data) {
-        Ok(_) => {
+        Ok(_) | Err(DpdError::Switch(AsicError::Exists)) => {
             info!(s.log, "set guest_traffic_allowed on {}", port);
             Ok(())
         }
@@ -99,7 +105,7 @@ pub fn uplink_clear(s: &Switch, port: u16) -> DpdResult<()> {
 
     let match_key = EgressMatchKey { out_port: port };
     match s.table_entry_del(TableType::UplinkEgress, &match_key) {
-        Ok(_) => {
+        Ok(_) | Err(DpdError::Switch(AsicError::Missing(_))) => {
             info!(s.log, "cleared guest_traffic_allowed on {}", port);
             Ok(())
         }


### PR DESCRIPTION
https://github.com/oxidecomputer/dendrite/issues/354

The reasoning here looks sound. I'll reproduce in a chaos test and propose a fix in another branch. This one will never merge.

---

# :robot: The link reconciler wedges on a partially-failed teardown

> `test_port_settings_txn_sweep` is flaky (~1 in 8) because `unplumb_link()`
> tracks several table entries behind one `plumbed` flag. When chaos fails one
> step, the retry re-runs the steps that already succeeded, gets
> `Missing("table entry not found")` — a *deterministic* error — and the link
> can never be deleted. Fix: make the clear/set paths converge instead of
> erroring on an entry that is already in the desired state.

## Symptom

```
cargo test --features chaos,multicast --test test_all test_port_settings_txn_sweep
...
Error: operation failed: desired settings: PortSettings { links: {} }
current settings: PortSettings { links: { "0": LinkSettings { addrs: [], ... } } }
```

The test asked for an empty port, `port_settings_apply` returned `Ok`, and then
`port_settings_get` kept reporting the link for the full 5 s retry window.
Reproduced ~1 run in 8 on `cory/ipwars2`; the bug is on `main` too — nothing in
that branch touches the code involved.

## Diagnosis

Link deletion is asynchronous: `apply_port_settings` only sets
`link.config.delete_me` and triggers the reconciler
(`dpd/src/port_settings.rs`). `get_port_settings` with `ignore_deleting=false`
reports the link until the reconciler actually removes it, so a wedged
reconciler shows up in the test as "the link never went away".

`reconcile_link()` (`dpd/src/link.rs`) calls `unplumb_link()`, and **returns
early without deleting the link if unplumb fails**. That is fine on its own —
the reconciler re-sweeps every ~1 s, so a transient failure just retries. The
problem is that the retry is not idempotent.

`unplumb_link()` gates its work on three `plumbed` fields, and two of those
gates cover *more than one* table entry:

| gate | table entries removed |
|------|----------------------|
| `plumbed.uplink` | `UplinkIngress`, `UplinkEgress` |
| `plumbed.mac.is_some()` | `PortMacAddress`, `PortMacAddressMcast`, `McastEgressPortMapping` |
| `plumbed.link_created` | the ASIC port itself |

The flag is only cleared after *all* of its entries are gone. So when chaos
fails the second or third entry, the flag stays set, the next sweep re-runs the
first entry's delete, and the ASIC returns
`AsicError::Missing("table entry not found")` — which is not chaos and will
never stop happening. The link is wedged for the life of the process.

The log signature, straight from `/tmp/txn-sweep-dpd.stdout`:

```
tearing down link marked for deletion
failed to delete entry from McastEgressPortMapping: Switch(Synthetic("table_entry_del"))   <- chaos, once
Failed to clear mac address and port mapping ...
                                                                    ... one second later ...
tearing down link marked for deletion
failed to delete entry from PortMacAddress: Switch(Missing("table entry not found"))       <- forever
```

`uplink_clear()` has the same shape with an extra twist: on an egress-delete
failure it compensates by re-adding the ingress entry, but that compensation is
itself `?`-propagated, so a second chaos hit leaves ingress deleted with
`plumbed.uplink` still true — and every later sweep dies on
`failed to delete entry from UplinkIngress: Missing(...)`.

The set/plumb direction has the mirror-image bug: `set_mac_config()` is three
adds behind one flag, so a partial failure makes the retry hit
`AsicError::Exists` forever.

## Fix

Give the reconciler's table operations "ensure this state" semantics instead of
"perform this operation", the way `dpd/src/loopback.rs` already does for
loopback addresses:

- `clear_mac_config()` — treat `Missing` as success (`ignore_missing()` helper
  in `link.rs`).
- `set_mac_config()` — on `Exists`, rewrite the entry rather than failing.
  Needed new `mac::mac_update()` / `mac::mcast_mac_update()` (mirroring
  `mac_set`/`mac_clear`), and gave `mcast_egress::update_port_mapping_entry()`
  its first caller, so its `#[allow(dead_code)]` came off.
- `dpd/src/table/uplink.rs` — `set_ingress_uplink` and the egress add accept
  `Exists`; `clear_ingress_uplink` and the egress delete accept `Missing`. Both
  tables carry an argument-free action, so an existing entry is by definition
  already correct. This also makes the compensation paths harmless.

Rewriting rather than swallowing `Exists` matters for the MAC tables: the entry
that is already there may hold a MAC from an earlier, half-completed attempt.

Files: `dpd/src/link.rs`, `dpd/src/table/mac.rs`, `dpd/src/table/uplink.rs`,
`dpd/src/table/mcast/mcast_egress.rs`.

**Alternative considered and rejected:** split `plumbed.mac` and
`plumbed.uplink` into one flag per table entry. That is more faithful
bookkeeping, but it is more state to keep correct and it does not help the real
hardware case, where dpd's shadow can be wrong about the ASIC for reasons other
than a failed call. Idempotent operations fix both.

## Reproducing

The chaos harness runs `target/debug/dpd`, which `cargo test -p dpd-client`
does **not** build — build it separately or you will test a stale daemon:

```bash
bin/hx -C dendrite 'cargo build -p dpd --features chaos,multicast'
bin/hx -C dendrite/dpd-client \
  'cargo test --features chaos,multicast --test test_all test_port_settings_txn_sweep'
```

Loop it; one run is not evidence. dpd's own log for a run lands in
`/tmp/<test-name>-dpd.stdout` (here `/tmp/txn-sweep-dpd.stdout`) and is where
the diagnosis actually lives — the test's own output only shows the mismatched
`PortSettings`.

Fix rates measured on helios, `cory/ipwars2` (2026-09):

| build | failures |
|-------|----------|
| unpatched | run 2 of 12 |
| mac fix only | run 24 of 30 (uplink wedge) |
| both fixes | 30 of 30 clean |

## Related

- Chaos injection is uniform across every ASIC op at `OPERATION_FAILURE_RATE`
  (0.1) — `AsicConfig::uniform_set`. `asic/src/chaos/table.rs` checks
  Exists/Missing *before* rolling the chaos dice, so those two errors are always
  deterministic.
- [dendrite-reconciler-model.md](./dendrite-reconciler-model.md) — why `plumbed`
  is a shadow of what dpd wrote, never a readback.
